### PR TITLE
Fix/atomic normalization

### DIFF
--- a/lib/pipeline/stages/normalizer/impl/gnu_to_std_cpp_stage.cpp
+++ b/lib/pipeline/stages/normalizer/impl/gnu_to_std_cpp_stage.cpp
@@ -14,8 +14,6 @@
 using namespace oklt;
 using namespace clang;
 
-// #define NORMALIZER_DEBUG_LOG
-//
 namespace {
 struct AttrNormalizerCtx {
   ASTContext* astCtx;
@@ -23,19 +21,13 @@ struct AttrNormalizerCtx {
   std::list<OklAttrMarker> markers;
 };
 
-std::string wrapAsSpecificCxxAttr(const OklAttribute& attr) {
-  if (attr.params.empty()) {
-    return "[[okl::" + attr.name + R"((")" + "(void)" + "\")]]";
-  }
-
-  return "[[okl::" + attr.name + R"((")" + attr.params + "\")]]";
-}
 // TODO move to helper functions header
-constexpr uint32_t CXX11_ATTR_PREFIX_LEN = 2u;
-constexpr uint32_t CXX11_ATTR_SUFFIX_LEN = 2u;
+constexpr int32_t CXX11_ATTR_PREFIX_LEN = 2;
+constexpr int32_t CXX11_ATTR_SUFFIX_LEN = 2;
 
-constexpr uint32_t GNU_ATTR_PREFIX_LEN = 15u;
-constexpr uint32_t GNU_ATTR_SUFFIX_LEN = 2u;
+constexpr int32_t GNU_ATTR_PREFIX_LEN = 15;
+constexpr int32_t GNU_ATTR_SUFFIX_LEN = 2;
+
 SourceRange getAttrFullSourceRange(const Attr& attr) {
   auto arange = attr.getRange();
 

--- a/lib/pipeline/stages/normalizer/impl/okl_attribute.h
+++ b/lib/pipeline/stages/normalizer/impl/okl_attribute.h
@@ -11,4 +11,21 @@ struct OklAttribute {
   std::vector<size_t> tok_indecies;
 };
 
+inline static std::string wrapAsSpecificGnuAttr(const OklAttribute& attr) {
+  if (attr.params.empty()) {
+    return "__attribute__((okl_" + attr.name + R"((")" + "" + "\")))";
+  }
+
+  return "__attribute__((okl_" + attr.name + R"((")" + attr.params + "\")))";
+}
+
+inline static std::string wrapAsSpecificCxxAttr(const OklAttribute& attr) {
+  if (attr.params.empty()) {
+    return "[[okl::" + attr.name + R"((")" + "" + "\")]]";
+  }
+
+  return "[[okl::" + attr.name + R"((")" + attr.params + "\")]]";
+}
+
+
 }  // namespace oklt

--- a/tests/functional/configs/test_suite_normalize/atomic_test_case.json
+++ b/tests/functional/configs/test_suite_normalize/atomic_test_case.json
@@ -1,0 +1,9 @@
+[
+    {
+        "action": "normalizer",
+        "action_config": {
+            "source": "normalize/simple/atomic_diff_loc.cpp"
+        },
+        "reference": "normalize/simple/atomic_diff_loc_ref.cpp"
+     }
+]

--- a/tests/functional/configs/test_suite_normalize/suite.json
+++ b/tests/functional/configs/test_suite_normalize/suite.json
@@ -1,3 +1,4 @@
 [
-    "simple_normalize.json"
+    "simple_normalize.json",
+    "atomic_test_case.json"
 ]

--- a/tests/functional/data/normalize/simple/atomic_diff_loc.cpp
+++ b/tests/functional/data/normalize/simple/atomic_diff_loc.cpp
@@ -1,0 +1,14 @@
+@kernel void f(float a) {
+  @atomic a= a + 1;
+  [[okl::atomic("")]] a+= 1;
+
+  {
+    float b;
+    b = a+b @atomic;
+    @atomic b = a+b;
+  }
+
+  {
+    a *= 1 @atomic;
+  }
+}

--- a/tests/functional/data/normalize/simple/atomic_diff_loc_ref.cpp
+++ b/tests/functional/data/normalize/simple/atomic_diff_loc_ref.cpp
@@ -1,0 +1,14 @@
+[[okl::kernel("")]] void f(float a) {
+  [[okl::atomic("")]] a= a + 1;
+  [[okl::atomic("")]] a+= 1;
+
+  {
+    float b;
+    [[okl::atomic("")]]b = a+b ;
+    [[okl::atomic("")]] b = a+b;
+  }
+
+  {
+    [[okl::atomic("")]]a *= 1 ;
+  }
+}

--- a/tests/functional/data/normalize/simple/dim_multi_vars_decl_ref.cpp
+++ b/tests/functional/data/normalize/simple/dim_multi_vars_decl_ref.cpp
@@ -1,4 +1,4 @@
-[[okl::kernel("(void)")]] void addVectors(const int entries,
+[[okl::kernel("")]] void addVectors(const int entries,
                                           const float* a,
                                           const float* b,
                                           float* ab) {

--- a/tests/functional/data/normalize/simple/dim_single_var_decl_ref.cpp
+++ b/tests/functional/data/normalize/simple/dim_single_var_decl_ref.cpp
@@ -1,6 +1,6 @@
 [[okl::dim("(4,4)")]] typedef float* mat4;
 
-[[okl::kernel("(void)")]] void addVectors(const int entries,
+[[okl::kernel("")]] void addVectors(const int entries,
                                           [[okl::dim("(x,y)")]] const float* a,
                                           [[okl::dim("(y,x)")]] const float* b,
                                           float* ab) {

--- a/tests/functional/data/normalize/simple/simple1_ref.cpp
+++ b/tests/functional/data/normalize/simple/simple1_ref.cpp
@@ -1,8 +1,8 @@
-[[okl::kernel("(void)")]] void simple_function([[okl::restrict("(void)")]] const float* inputArray,
+[[okl::kernel("")]] void simple_function([[okl::restrict("")]] const float* inputArray,
                                                float* outputArray,
                                                float value,
                                                int size) {
-  [[okl::outer("(void)")]] for (int i = 0; i < size; ++i) {
+  [[okl::outer("")]] for (int i = 0; i < size; ++i) {
     outputArray[i] = inputArray[i] + value;
   }
 }


### PR DESCRIPTION
GNU attribute could no be used for some statements:
 
`
@atomic a+=1;
a+=1 @atomic; 
 `
This particular attribute is normalized on lexer stage to put CXX attribute in front of statement always.
TODO
Test another exotic usages