### PR TITLE
Ignore undaclare symbol

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -166,6 +166,7 @@ set (OCCA_TRANSPILER_SOURCES
     core/sema/okl_sema_info.h
 
     core/diag/diag_consumer.cpp
+    core/diag/builtin_handlers/ignore_undecl_indent.cpp
 
     core/kernel_metadata.cpp
 

--- a/lib/attributes/frontend/max_inner_dim.cpp
+++ b/lib/attributes/frontend/max_inner_dim.cpp
@@ -1,0 +1,83 @@
+#include "attributes/attribute_names.h"
+#include "core/attribute_manager/attribute_manager.h"
+
+#include "attributes/utils/parser.h"
+#include "params/loop.h"
+
+#include <oklt/util/string_utils.h>
+
+#include <clang/Basic/DiagnosticSema.h>
+#include <clang/Sema/ParsedAttr.h>
+#include <clang/Sema/Sema.h>
+
+namespace {
+
+using namespace clang;
+using namespace oklt;
+
+constexpr ParsedAttrInfo::Spelling OUTER_ATTRIBUTE_SPELLINGS[] = {
+    {ParsedAttr::AS_CXX11, "max_inner_dim"},
+    {ParsedAttr::AS_CXX11, MAX_INNER_DIM},
+    {ParsedAttr::AS_GNU, "okl_inner_dim"}};
+
+struct MaxInnerDim : public ParsedAttrInfo {
+    MaxInnerDim() {
+        NumArgs = 1;
+        OptArgs = 0;
+        Spellings = OUTER_ATTRIBUTE_SPELLINGS;
+        AttrKind = clang::AttributeCommonInfo::AT_Suppress;
+        IsStmt = true;
+    }
+
+    bool diagAppertainsToStmt(clang::Sema& sema,
+                              const clang::ParsedAttr& attr,
+                              const clang::Stmt* stmt) const override {
+        if (!isa<ForStmt>(stmt)) {
+            sema.Diag(attr.getLoc(), diag::err_attribute_wrong_decl_type_str)
+                << attr << attr.isDeclspecAttribute() << "for statement";
+            return false;
+        }
+        return true;
+    }
+
+    bool diagAppertainsToDecl(clang::Sema& sema,
+                              const clang::ParsedAttr& attr,
+                              const clang::Decl* decl) const override {
+        // INFO: fail for all decls
+        sema.Diag(attr.getLoc(), diag::err_attribute_wrong_decl_type_str)
+            << attr << attr.isDeclspecAttribute() << "for statement";
+        return false;
+    }
+};
+
+ParseResult parseMaxInnerDim(const clang::Attr& attr,
+                                 OKLParsedAttr& data,
+                                 SessionStage& stage) {
+    if (!data.kwargs.empty()) {
+        return tl::make_unexpected(Error{{}, "[@outer] does not take kwargs"});
+    }
+
+    if (data.args.size() > 1) {
+        return tl::make_unexpected(Error{{}, "[@outer] takes at most one index"});
+    }
+
+    AttributedLoop ret{
+        .type = LoopType::Outer,
+        .axis = Axis::Auto,
+    };
+
+    if (auto dimSize = data.get<int>(0); dimSize.has_value()) {
+        if (dimSize.value() < 0 || dimSize.value() > 2) {
+            return tl::make_unexpected(Error{{}, "[@outer] argument must be 0, 1, or 2"});
+        }
+        ret.axis = static_cast<Axis>(dimSize.value());
+    }
+
+    return ret;
+}
+
+__attribute__((constructor)) void registerAttrFrontend() {
+    AttributeManager::instance().registerAttrFrontend<MaxInnerDim>(OUTER_ATTR_NAME,
+                                                                      parseMaxInnerDim);
+}
+}  // namespace

--- a/lib/core/diag/builtin_handlers/ignore_undecl_indent.cpp
+++ b/lib/core/diag/builtin_handlers/ignore_undecl_indent.cpp
@@ -1,0 +1,30 @@
+#include "core/diag/diag_handler.h"
+#include "core/transpiler_session/session_stage.h"
+
+#include <clang/Basic/DiagnosticSema.h>
+#include <llvm/Support/ManagedStatic.h>
+
+namespace {
+using namespace oklt;
+using namespace clang;
+
+class IgnoreUndeclHandler : public DiagHandler {
+   public:
+    IgnoreUndeclHandler()
+        : DiagHandler(diag::err_undeclared_var_use){};
+
+    bool HandleDiagnostic(SessionStage& session, DiagLevel level, const Diagnostic& info) override {
+        // TODO unify with error reporting to get correct location and source line
+        llvm::SmallString<64> buf;
+        info.FormatDiagnostic(buf);
+        std::string msg{buf.begin(), buf.end()};
+
+        FullSourceLoc loc(info.getLocation(), session.getCompiler().getSourceManager());
+
+        session.pushWarning(std::to_string(loc.getLineNumber()) + ":" + msg.data());
+        return true;
+    }
+};
+
+oklt::DiagHandlerRegistry::Add<IgnoreUndeclHandler> diag_dim("IgnoreUndeclUse", "");
+}  // namespace

--- a/lib/pipeline/stages/transpiler/transpiler.cpp
+++ b/lib/pipeline/stages/transpiler/transpiler.cpp
@@ -43,6 +43,17 @@ TranspilerSessionResult runTranspilerStage(SharedTranspilerSession session) {
                                      file_name,
                                      tool_name,
                                      std::make_shared<PCHContainerOperations>());
+
+// TODO make reporting of warnings as runtime option
+#ifdef TRANSPILER_DEBUG_LOG
+    const auto& warnings = session->getWarnings();
+    if (!warnings.empty()) {
+        llvm::outs() << "tranpilation warnings:\n";
+        for (const auto& w : warnings) {
+            llvm::outs() << w.desc << "\n";
+        }
+    }
+#endif
     if (!ret || !session->getErrors().empty()) {
         return tl::make_unexpected(std::move(session->getErrors()));
     }

--- a/tests/functional/configs/test_suite_transpiler/backends/cuda/ignore_undecl_var.json
+++ b/tests/functional/configs/test_suite_transpiler/backends/cuda/ignore_undecl_var.json
@@ -1,0 +1,13 @@
+[
+    {
+        "action": "normalize_and_transpile",
+        "action_config": {
+            "backend": "cuda",
+            "source": "transpiler/backends/cuda/undeclare_var/ignore_use_of_undecl_var.cpp",
+            "includes": [],
+            "defs": [],
+            "launcher": ""
+        },
+        "reference": "transpiler/backends/cuda/undeclare_var/ignore_use_of_undecl_var_ref.cpp"
+     }
+]

--- a/tests/functional/data/transpiler/backends/cuda/cuda/undecl_use/allow_undecl_symb.cpp
+++ b/tests/functional/data/transpiler/backends/cuda/cuda/undecl_use/allow_undecl_symb.cpp
@@ -1,0 +1,9 @@
+@kernel void hello_kern() {
+    for (int i = 0; i < 10; ++i; @outer) {
+        for (int j = 0; j < 10; ++j; @inner) {
+            float var = 10.0;
+            float res = __exp10f(var);
+            auto ok = std::isnan(var);
+        }
+    }
+}

--- a/tests/functional/data/transpiler/backends/cuda/undeclare_var/ignore_use_of_undecl_var.cpp
+++ b/tests/functional/data/transpiler/backends/cuda/undeclare_var/ignore_use_of_undecl_var.cpp
@@ -1,0 +1,9 @@
+@kernel void hello_kern() {
+    for (int i = 0; i < 10; ++i; @outer) {
+        for (int j = 0; j < 10; ++j; @inner) {
+            float var = 10.0;
+            float res = __exp10f(var);
+            auto ok = std::isnan(var);
+        }
+    }
+}

--- a/tests/functional/data/transpiler/backends/cuda/undeclare_var/ignore_use_of_undecl_var_ref.cpp
+++ b/tests/functional/data/transpiler/backends/cuda/undeclare_var/ignore_use_of_undecl_var_ref.cpp
@@ -1,0 +1,13 @@
+#include <cuda_runtime.h>
+
+extern "C" __global__ void _occa_hello_kern_0() {
+  {
+    int i = (0) + blockIdx.x;
+    {
+      int j = (0) + threadIdx.x;
+      float var = 10.0;
+      float res = __exp10f(var);
+      auto ok = std::isnan(var);
+    }
+  }
+}

--- a/tests/functional/data/transpiler/common/macro/kw_under_macro_ref.cpp
+++ b/tests/functional/data/transpiler/common/macro/kw_under_macro_ref.cpp
@@ -8,17 +8,15 @@ typedef struct {
 float* __restrict__ aa;
 
 extern "C" __global__ void _occa_hello_kern_0(S* a) {
-    int i = (0) + blockIdx.x;
     {
+        int i = (0) + blockIdx.x;
         __shared__ float buf[100];
         int a, b;
         {
             int j = (0) + threadIdx.x;
-            {
-                a += 1;
-                b += 1;
-                __syncthreads();
-            }
+            a += 1;
+            b += 1;
+            __syncthreads();
         }
     }
 }


### PR DESCRIPTION
Legacy OCCA transpiler ignore undeclare symbols and allows to use intrinsic and std:: var/func.
Let's for now obey this rule.