### PR TITLE
preprocessor is already initialized, there should not be double initialization

### DIFF
--- a/lib/pipeline/stages/normalizer/impl/expand_macro_stage.cpp
+++ b/lib/pipeline/stages/normalizer/impl/expand_macro_stage.cpp
@@ -292,7 +292,7 @@ ExpandMacroResult expandMacro(ExpandMacroStageInput input) {
 
     Twine tool_name = "okl-transpiler-normalization-to-gnu";
     Twine file_name("main_kernel.cpp");
-    std::vector<std::string> args = {"-std=c++17", "-fparse-all-comments", "-I.", "-v"};
+    std::vector<std::string> args = {"-std=c++17", "-fparse-all-comments", "-I."};
 
     auto input_file = std::move(input.cppSrc);
 


### PR DESCRIPTION
it takes the preprocessor from the already compiler instance. It's already initialized
Under the debug mode it fails with assert about the double initialization 