### PR TITLE
add new line after expanding directive if needed

### DIFF
--- a/lib/pipeline/stages/normalizer/impl/okl_macro_stage.cpp
+++ b/lib/pipeline/stages/normalizer/impl/okl_macro_stage.cpp
@@ -69,15 +69,27 @@ bool replaceOklMacroAttribute(const OklAttribute& oklAttr,
     }
 
     auto replacement = lit.GetString().str();
-    // in case of one line source code add new line character due to directive expand macro that
-    // actually will hide all source code
+
+    // in case of one line source code add new line character before and after directive expand to
+    // ensure source is not hidden by macro that could be inside of directive
     if (oklAttr.tok_indecies.back() != tokens.size()) {
-        FullSourceLoc attrLastToken(tokens[oklAttr.tok_indecies.back()].getLocation(),
-                                    pp.getSourceManager());
+        FullSourceLoc nextTokenAfterAttr(tokens[oklAttr.tok_indecies.back()].getLocation(),
+                                         pp.getSourceManager());
         FullSourceLoc nextTokenFullLoc(tokens[oklAttr.tok_indecies.back() + 1].getLocation(),
                                        pp.getSourceManager());
-        if (attrLastToken.getExpansionLineNumber() == nextTokenFullLoc.getExpansionLineNumber()) {
+        if (nextTokenAfterAttr.getExpansionLineNumber() ==
+            nextTokenFullLoc.getExpansionLineNumber()) {
             replacement += '\n';
+        }
+    }
+    if (oklAttr.tok_indecies.front() != 0) {
+        FullSourceLoc prevTokenAfterAttr(tokens[oklAttr.tok_indecies.back()].getLocation(),
+                                         pp.getSourceManager());
+        FullSourceLoc nextTokenFullLoc(tokens[oklAttr.tok_indecies.back() + 1].getLocation(),
+                                       pp.getSourceManager());
+        if (prevTokenAfterAttr.getExpansionLineNumber() ==
+            nextTokenFullLoc.getExpansionLineNumber()) {
+            replacement = '\n' + replacement;
         }
     }
 

--- a/lib/pipeline/stages/normalizer/impl/okl_macro_stage.cpp
+++ b/lib/pipeline/stages/normalizer/impl/okl_macro_stage.cpp
@@ -68,7 +68,20 @@ bool replaceOklMacroAttribute(const OklAttribute& oklAttr,
         return false;
     }
 
-    rewriter.InsertTextBefore(insertLoc, lit.GetString());
+    auto replacement = lit.GetString().str();
+    // in case of one line source code add new line character due to directive expand macro that
+    // actually will hide all source code
+    if (oklAttr.tok_indecies.back() != tokens.size()) {
+        FullSourceLoc attrLastToken(tokens[oklAttr.tok_indecies.back()].getLocation(),
+                                    pp.getSourceManager());
+        FullSourceLoc nextTokenFullLoc(tokens[oklAttr.tok_indecies.back() + 1].getLocation(),
+                                       pp.getSourceManager());
+        if (attrLastToken.getExpansionLineNumber() == nextTokenFullLoc.getExpansionLineNumber()) {
+            replacement += '\n';
+        }
+    }
+
+    rewriter.InsertTextBefore(insertLoc, replacement);
 
 #ifdef NORMALIZER_DEBUG_LOG
     llvm::outs() << "removed macro attr: " << oklAttr.name

--- a/tests/functional/configs/test_suite_transpiler/common/macro/kw_under_macro.json
+++ b/tests/functional/configs/test_suite_transpiler/common/macro/kw_under_macro.json
@@ -14,6 +14,17 @@
         "action": "normalize_and_transpile",
         "action_config": {
             "backend": "cuda",
+            "source": "transpiler/common/macro/directive_with_one_line_source.cpp",
+            "includes": [],
+            "defs": [],
+            "launcher": ""
+        },
+        "reference": "transpiler/common/macro/directive_with_one_line_source_ref.cpp"
+    },
+    {
+        "action": "normalize_and_transpile",
+        "action_config": {
+            "backend": "cuda",
             "source": "transpiler/common/macro/empty_macro_with_arg.cpp",
             "includes": [],
             "defs": [],

--- a/tests/functional/data/normalize/simple/macro_ifdef_ref.cpp
+++ b/tests/functional/data/normalize/simple/macro_ifdef_ref.cpp
@@ -5,6 +5,7 @@ void use_some_type(UnknownType hello);
 #endif
 
 [[okl::kernel("")]] void kern() {
+
     [[okl::outer("")]] for (int i = 0; i < 10; i++) {
         [[okl::inner("")]] for (int j = 0; j < 10; j++) {}
     }

--- a/tests/functional/data/transpiler/common/macro/directive_with_one_line_source.cpp
+++ b/tests/functional/data/transpiler/common/macro/directive_with_one_line_source.cpp
@@ -1,0 +1,1 @@
+@directive("#define MYMACRO 0") @kernel void hello_kern() { for (int i = 0; i < 10; ++i; @outer) { for (int j = 0; j < 10; ++j; @inner) {}} }

--- a/tests/functional/data/transpiler/common/macro/directive_with_one_line_source.cpp
+++ b/tests/functional/data/transpiler/common/macro/directive_with_one_line_source.cpp
@@ -1,1 +1,1 @@
-@directive("#define MYMACRO 0") @kernel void hello_kern() { for (int i = 0; i < 10; ++i; @outer) { for (int j = 0; j < 10; ++j; @inner) {}} }
+@directive("#define MYMACRO 0") @kernel void hello_kern() { for (int i = 0; i < 10; ++i; @outer) { for (int j = 0; j < 10; ++j; @inner) { @directive("#ifdef MYMACRO") int a = 0; @directive("#else") int a = 1; @directive("#endif")  }} }

--- a/tests/functional/data/transpiler/common/macro/directive_with_one_line_source_ref.cpp
+++ b/tests/functional/data/transpiler/common/macro/directive_with_one_line_source_ref.cpp
@@ -1,0 +1,8 @@
+#include <cuda_runtime.h>
+
+extern "C" __global__ __launch_bounds__(10) void _occa_hello_kern_0() {
+  {
+    int i = (0) + blockIdx.x;
+    { int j = (0) + threadIdx.x; }
+  }
+}

--- a/tests/functional/data/transpiler/common/macro/directive_with_one_line_source_ref.cpp
+++ b/tests/functional/data/transpiler/common/macro/directive_with_one_line_source_ref.cpp
@@ -3,6 +3,9 @@
 extern "C" __global__ __launch_bounds__(10) void _occa_hello_kern_0() {
   {
     int i = (0) + blockIdx.x;
-    { int j = (0) + threadIdx.x; }
+    {
+      int j = (0) + threadIdx.x;
+      int a = 0;
+    }
   }
 }


### PR DESCRIPTION
If the next token after directive expansion is at the same line add new line character to prevent source code to be hidden after macro.