### PR TITLE
remove commnet behind the macro

### DIFF
--- a/lib/attributes/utils/replace_attribute.cpp
+++ b/lib/attributes/utils/replace_attribute.cpp
@@ -55,7 +55,9 @@ HandleResult handleGlobalFunction(const clang::FunctionDecl& decl,
     auto loc = decl.getSourceRange().getBegin();
     auto spacedModifier = funcQualifier + " ";
 
-    SPDLOG_DEBUG("Handle global function '{}'", decl.getNameAsString());
+    SPDLOG_DEBUG("Handle global function '{}' at {}",
+                 decl.getNameAsString(),
+                 decl.getLocation().printToString(s.getCompiler().getSourceManager()));
 
     s.getRewriter().InsertTextBefore(loc, spacedModifier);
 
@@ -65,13 +67,6 @@ HandleResult handleGlobalFunction(const clang::FunctionDecl& decl,
 HandleResult handleCXXRecord(const clang::CXXRecordDecl& cxxRecord,
                              SessionStage& s,
                              const std::string& qualifier) {
-    const auto& sm = s.getCompiler().getSourceManager();
-    // TODO move the logic to ast traversal to be common for all handlers
-    // skip system headers
-    if (SrcMgr::isSystem(sm.getFileCharacteristic(cxxRecord.getLocation()))) {
-        return {};
-    }
-
     auto spacedModifier = qualifier + " ";
 
     // for all explicit constructors/methods add qualifier

--- a/lib/core/ast_traversal/preorder_traversal_nlr.cpp
+++ b/lib/core/ast_traversal/preorder_traversal_nlr.cpp
@@ -187,12 +187,30 @@ HandleResult runFromLeavesToRoot(TraversalType& traversal,
     return {};
 }
 
+template <typename NodeType>
+bool skipNode(const NodeType& n, SessionStage& s) {
+    const auto& sm = s.getCompiler().getSourceManager();
+    if (sm.isInSystemHeader(n.getBeginLoc())) {
+        return true;
+    }
+
+    if (sm.isInSystemMacro(n.getBeginLoc())) {
+        return true;
+    }
+
+    return false;
+}
+
 template <typename TraversalType, typename NodeType>
 bool traverseNode(TraversalType& traversal,
                   NodeType* node,
                   AstProcessorManager& procMng,
                   SessionStage& stage) {
     if (node == nullptr) {
+        return true;
+    }
+
+    if (skipNode(*node, stage)) {
         return true;
     }
 

--- a/lib/core/transpiler_session/code_generator.cpp
+++ b/lib/core/transpiler_session/code_generator.cpp
@@ -120,6 +120,8 @@ tl::expected<std::string, Error> preprocessedInputs(const TransformedFiles& inpu
     // set options from parent compiler
     invocation->getHeaderSearchOpts() = stage.getCompiler().getHeaderSearchOpts();
     invocation->getPreprocessorOpts() = stage.getCompiler().getPreprocessorOpts();
+    // TODO get this info from user input aka json prop file
+    invocation->getDiagnosticOpts().Warnings = {"no-extra-tokens", "no-invalid-pp-token"};
 
     invocation->getFrontendOpts().Inputs.push_back(
         FrontendInputFile("okl_kernel.cpp", Language::CXX));

--- a/lib/pipeline/stages/normalizer/impl/expand_macro_stage.cpp
+++ b/lib/pipeline/stages/normalizer/impl/expand_macro_stage.cpp
@@ -196,12 +196,9 @@ class DefCondDirectiveCallbacks : public PPCallbacks {
 
         auto* mi = md.getMacroInfo();
         if (!mi) {
-            results.emplace_back(SourceRange{loc, macroNameTok.getLocation()},
-                                 std::string("if ") + (isEnabled(loc, md) ? "0" : "1"));
             return;
         }
-
-        if (md.getMacroInfo()->isUsedForHeaderGuard()) {
+        if (mi->isUsedForHeaderGuard()) {
             return;
         }
 

--- a/lib/pipeline/stages/transpiler/transpiler.cpp
+++ b/lib/pipeline/stages/transpiler/transpiler.cpp
@@ -26,7 +26,9 @@ TranspilerSessionResult runTranspilerStage(SharedTranspilerSession session) {
     // INFO: hot fix for *.okl extention
     std::string rawFileName = "main_kernel.cpp";
     Twine file_name(rawFileName);
-    std::vector<std::string> args = {"-std=c++17", "-fparse-all-comments", "-I."};
+
+    // TODO get this info from user input aka json prop file
+    std::vector<std::string> args = {"-std=c++17", "-Wno-extra-tokens", "-Wno-invalid-pp-token", "-fparse-all-comments", "-I."};
 
     for (const auto& define : input.defines) {
         std::string def = "-D" + define;

--- a/tests/functional/configs/test_suite_transpiler/common/macro/kw_under_macro.json
+++ b/tests/functional/configs/test_suite_transpiler/common/macro/kw_under_macro.json
@@ -25,6 +25,17 @@
         "action": "normalize_and_transpile",
         "action_config": {
             "backend": "cuda",
+            "source": "transpiler/common/macro/directive_with_comments.cpp",
+            "includes": [],
+            "defs": [],
+            "launcher": ""
+        },
+        "reference": "transpiler/common/macro/directive_with_comments_ref.cpp"
+    },
+    {
+        "action": "normalize_and_transpile",
+        "action_config": {
+            "backend": "cuda",
             "source": "transpiler/common/macro/empty_macro_with_arg.cpp",
             "includes": [],
             "defs": [],

--- a/tests/functional/data/transpiler/common/macro/directive_with_comments.cpp
+++ b/tests/functional/data/transpiler/common/macro/directive_with_comments.cpp
@@ -1,0 +1,14 @@
+#define MYMACRO 1  // my first comment
+
+#if MYMACRO  //  my second comment
+
+#define HELLOMACRO 1
+
+#endif  //  my third comment
+
+@kernel void hello_kern() {
+    for (int i = 0; i < 10; ++i; @outer) {
+        for (int j = 0; j < 10; ++j; @inner) {
+        }
+    }
+}

--- a/tests/functional/data/transpiler/common/macro/directive_with_comments_ref.cpp
+++ b/tests/functional/data/transpiler/common/macro/directive_with_comments_ref.cpp
@@ -1,0 +1,8 @@
+#include <cuda_runtime.h>
+
+extern "C" __global__ __launch_bounds__(10) void _occa_hello_kern_0() {
+  {
+    int i = (0) + blockIdx.x;
+    { int j = (0) + threadIdx.x; }
+  }
+}


### PR DESCRIPTION
Comment after macro is tricky and buggy thing.
In general for transpilation to remove all comments and preserving lines structure is beneficial due to simplifying parsing. 
So far just try to remove all comments that are defined in same line as macro/directive.