### PR TITLE
Run implicit handler unconditionally on availability of attributes

### DIFF
--- a/lib/pipeline/stages/transpiler/transpilation.cpp
+++ b/lib/pipeline/stages/transpiler/transpilation.cpp
@@ -178,10 +178,10 @@ HandleResult runFromLeavesToRoot(TraversalType& traversal,
             result.error().ctx = node.getSourceRange();
             return result;
         }
-        if (stage.getAttrManager().hasImplicitHandler(stage.getBackend(), getNodeType(node))) {
-            transpilationAccumulator.push_back(TranspilationNode{
-                .ki = ki, .li = cl, .attr = nullptr, .node = DynTypedNode::create(node)});
-        }
+    }
+    if (stage.getAttrManager().hasImplicitHandler(stage.getBackend(), getNodeType(node))) {
+        transpilationAccumulator.push_back(TranspilationNode{
+            .ki = ki, .li = cl, .attr = nullptr, .node = DynTypedNode::create(node)});
     }
 
     // attributed node


### PR DESCRIPTION
Allow to run implicit handler on top of explicit to fix second part of https://github.com/libocca/occa-transpiler/issues/175 