### PR TITLE
Add compatible implicit-attribute handlers map

### DIFF
--- a/lib/attributes/backend/cuda/restrict.cpp
+++ b/lib/attributes/backend/cuda/restrict.cpp
@@ -13,6 +13,11 @@ __attribute__((constructor)) void registerCUDARestrictHandler() {
         {TargetBackend::CUDA, RESTRICT_ATTR_NAME},
         makeSpecificAttrHandle(cuda_subset::handleRestrictAttribute));
 
+    // allow @restrict in return type case
+    ok &= oklt::AttributeManager::instance().registerCompatibleImplicitAttributePair(
+        {TargetBackend::CUDA, clang::Decl::Kind::Function},
+        {TargetBackend::CUDA, RESTRICT_ATTR_NAME});
+
     if (!ok) {
         SPDLOG_ERROR("[CUDA] Failed to register {} attribute handler", RESTRICT_ATTR_NAME);
     }

--- a/lib/attributes/backend/hip/restrict.cpp
+++ b/lib/attributes/backend/hip/restrict.cpp
@@ -13,6 +13,11 @@ __attribute__((constructor)) void registerCUDARestrictHandler() {
         {TargetBackend::HIP, RESTRICT_ATTR_NAME},
         makeSpecificAttrHandle(cuda_subset::handleRestrictAttribute));
 
+    // allow @restrict in return type case
+    ok &= oklt::AttributeManager::instance().registerCompatibleImplicitAttributePair(
+        {TargetBackend::HIP, clang::Decl::Kind::Function},
+        {TargetBackend::HIP, RESTRICT_ATTR_NAME});
+
     if (!ok) {
         SPDLOG_ERROR("[HIP] Failed to register {} attribute handler", RESTRICT_ATTR_NAME);
     }

--- a/lib/core/attribute_manager/attribute_manager.cpp
+++ b/lib/core/attribute_manager/attribute_manager.cpp
@@ -44,6 +44,17 @@ bool AttributeManager::registerImplicitHandler(ImplicitHandlerMap::KeyType key,
     return _implicitHandlers.registerHandler(std::move(key), std::move(handler));
 }
 
+bool AttributeManager::registerCompatibleImplicitAttributePair(
+    ImplicitHandlerMap::KeyType implicitKey,
+    BackendAttributeMap::KeyType attributeKey) {
+    auto p = std::make_pair(implicitKey, attributeKey);
+    if (_compatibleImplicitAttributeHandlers.count(p)) {
+        return false;
+    }
+    _compatibleImplicitAttributeHandlers.insert(p);
+    return true;
+}
+
 HandleResult AttributeManager::handleNode(const Stmt& stmt, SessionStage& stage) {
     return _implicitHandlers(stmt, stage);
 }

--- a/lib/core/attribute_manager/attribute_manager.h
+++ b/lib/core/attribute_manager/attribute_manager.h
@@ -52,11 +52,20 @@ class AttributeManager {
     bool registerImplicitHandler(ImplicitHandlerMap::KeyType key, DeclHandler handler);
     bool registerImplicitHandler(ImplicitHandlerMap::KeyType key, StmtHandler handler);
 
+    bool registerCompatibleImplicitAttributePair(ImplicitHandlerMap::KeyType impicitKey,
+                                                 BackendAttributeMap::KeyType attributeKey);
+
     ParseResult parseAttr(const clang::Attr& attr, SessionStage& stage);
     ParseResult parseAttr(const clang::Attr& attr, OKLParsedAttr& params, SessionStage& stage);
 
     bool hasImplicitHandler(TargetBackend backend, int nodeType) {
         return _implicitHandlers.hasHandler({backend, nodeType});
+    }
+
+    bool areCompatibleHandlers(ImplicitHandlerMap::KeyType implicitKey,
+                               BackendAttributeMap::KeyType attributeKey) {
+        return _compatibleImplicitAttributeHandlers.count(
+            std::make_pair(implicitKey, attributeKey));
     }
 
     HandleResult handleAttr(const clang::Attr& attr,
@@ -85,6 +94,8 @@ class AttributeManager {
     BackendAttributeMap _backendAttrs;
     ImplicitHandlerMap _implicitHandlers;
     std::map<std::string, AttrParamParserType> _attrParsers;
+    std::set<std::pair<ImplicitHandlerMap::KeyType, BackendAttributeMap::KeyType>>
+        _compatibleImplicitAttributeHandlers;
 };
 
 namespace detail {

--- a/tests/functional/data/transpiler/backends/cuda/restrict/restrict_return_type_ref.cpp
+++ b/tests/functional/data/transpiler/backends/cuda/restrict/restrict_return_type_ref.cpp
@@ -1,6 +1,6 @@
 #include <cuda_runtime.h>
 
-float *__restrict__ myfn(float *a) { return a + 1; }
+__device__ float *__restrict__ myfn(float *a) { return a + 1; }
 
 extern "C" __global__ __launch_bounds__(10) void _occa_hello_0() {
   {


### PR DESCRIPTION
Save compatible implicit and attribute handlers set to allow some edge cases (such as mentioned in https://github.com/libocca/occa-transpiler/issues/175 -- @restrict to return type of global function)