### PR TITLE
Hot fix to skip system header processing

### DIFF
--- a/lib/attributes/utils/replace_attribute.cpp
+++ b/lib/attributes/utils/replace_attribute.cpp
@@ -48,6 +48,12 @@ using namespace clang;
 HandleResult handleGlobalConstant(const clang::VarDecl& decl,
                                   SessionStage& s,
                                   const std::string& qualifier) {
+
+    // skip decl with invalid soucce location
+    if (decl.getLocation().isInvalid()) {
+        return {};
+    }
+
     if (!isGlobalConstVariable(decl)) {
         return {};
     }
@@ -85,6 +91,11 @@ HandleResult handleGlobalConstant(const clang::VarDecl& decl,
 HandleResult handleGlobalFunction(const clang::FunctionDecl& decl,
                                   SessionStage& s,
                                   const std::string& funcQualifier) {
+    // skip built in functions or with invalid soucce location
+    if (decl.getLocation().isInvalid() || decl.isInlineBuiltinDeclaration()) {
+        return {};
+    }
+
     // INFO: Check if function is not attributed with OKL attribute
     auto loc = decl.getSourceRange().getBegin();
     auto spacedModifier = funcQualifier + " ";

--- a/lib/core/lex/lexer.cpp
+++ b/lib/core/lex/lexer.cpp
@@ -9,12 +9,18 @@ using namespace clang;
 std::vector<clang::Token> fetchTokens(
     clang::Preprocessor& pp,
     std::optional<std::function<bool(const clang::Token)>> watcher) {
+    const auto& sm = pp.getSourceManager();
     std::vector<Token> tokens;
 
     pp.EnterMainSourceFile();
     while (true) {
         Token tok{};
         pp.Lex(tok);
+
+        // only include tokens from user input source,headers
+        if (sm.isInSystemHeader(tok.getLocation())) {
+            continue;
+        }
 
         if (tok.is(tok::eof)) {
             break;

--- a/lib/pipeline/stages/transpiler/transpilation.cpp
+++ b/lib/pipeline/stages/transpiler/transpilation.cpp
@@ -223,8 +223,10 @@ bool traverseNode(TraversalType& traversal,
         return true;
     }
 
+    // node in non user header - skip traverse it
+    // TODO add more robust verification
     if (skipNode(*node, stage)) {
-        return dispatchTraverseFunc(traversal, node);
+        return true;
     }
 
     auto result = [&]() -> HandleResult {


### PR DESCRIPTION
- traverse nodes only for user input file;
- check validity of source location for global function and variable 