### PR TITLE
Always call implicit handle. Make glob function handle skip @kernel

### DIFF
--- a/lib/attributes/frontend/restrict.cpp
+++ b/lib/attributes/frontend/restrict.cpp
@@ -51,7 +51,7 @@ struct RestrictAttribute : public ParsedAttrInfo {
 
         if (!type->isPointerType() && !type->isArrayType()) {
             sema.Diag(attr.getLoc(), diag::err_attribute_wrong_decl_type_str)
-                << attr << ": supports only pointer type";
+                << attr << ":" << "pointer type";
             return false;
         }
         return true;

--- a/lib/attributes/utils/replace_attribute.cpp
+++ b/lib/attributes/utils/replace_attribute.cpp
@@ -1,9 +1,11 @@
 #include "attributes/utils/replace_attribute.h"
+#include "attributes/attribute_names.h"
 #include "core/transpiler_session/header_info.h"
 #include "core/transpiler_session/session_stage.h"
 #include "core/utils/var_decl.h"
 
 #include <clang/AST/AST.h>
+#include <clang/AST/Attr.h>
 
 #include <spdlog/spdlog.h>
 
@@ -88,6 +90,16 @@ HandleResult handleGlobalFunction(const clang::FunctionDecl& decl,
     // INFO: Check if function is not attributed with OKL attribute
     auto loc = decl.getSourceRange().getBegin();
     auto spacedModifier = funcQualifier + " ";
+
+    // If function is @kernel, we don't handle it
+    for (auto* attr : decl.getAttrs()) {
+        if (attr->getNormalizedFullName() == KERNEL_ATTR_NAME) {
+            SPDLOG_DEBUG(
+                "Global function handler skipped function {}, since it has @kernel attribute",
+                decl.getNameAsString());
+            return {};
+        }
+    }
 
     SPDLOG_DEBUG("Handle global function '{}' at {}",
                  decl.getNameAsString(),

--- a/lib/pipeline/stages/transpiler/transpilation.cpp
+++ b/lib/pipeline/stages/transpiler/transpilation.cpp
@@ -178,10 +178,6 @@ HandleResult runFromLeavesToRoot(TraversalType& traversal,
             result.error().ctx = node.getSourceRange();
             return result;
         }
-        if (stage.getAttrManager().hasImplicitHandler(stage.getBackend(), getNodeType(node))) {
-            transpilationAccumulator.push_back(TranspilationNode{
-                .ki = ki, .li = cl, .attr = nullptr, .node = DynTypedNode::create(node)});
-        }
     }
 
     // attributed node
@@ -193,6 +189,11 @@ HandleResult runFromLeavesToRoot(TraversalType& traversal,
         }
         transpilationAccumulator.push_back(TranspilationNode{
             .ki = ki, .li = cl, .attr = attr, .node = DynTypedNode::create(node)});
+    }
+
+    if (stage.getAttrManager().hasImplicitHandler(stage.getBackend(), getNodeType(node))) {
+        transpilationAccumulator.push_back(TranspilationNode{
+            .ki = ki, .li = cl, .attr = nullptr, .node = DynTypedNode::create(node)});
     }
 
     return {};

--- a/tests/functional/data/transpiler/backends/cuda/restrict/restrict_return_type.cpp
+++ b/tests/functional/data/transpiler/backends/cuda/restrict/restrict_return_type.cpp
@@ -2,6 +2,10 @@ float* @restrict myfn(float* a) {
     return a + 1;
 }
 
+float* myfn2(float* a) {
+    return a + 1;
+}
+
 @kernel void hello() {
     for (int i = 0; i < 10; i++; @outer) {
         for (int j = 0; j < 10; j++; @inner) {

--- a/tests/functional/data/transpiler/backends/cuda/restrict/restrict_return_type_ref.cpp
+++ b/tests/functional/data/transpiler/backends/cuda/restrict/restrict_return_type_ref.cpp
@@ -1,6 +1,8 @@
 #include <cuda_runtime.h>
 
-float *__restrict__ myfn(float *a) { return a + 1; }
+__device__ float *__restrict__ myfn(float *a) { return a + 1; }
+
+__device__ float * myfn2(float *a) { return a + 1; }
 
 extern "C" __global__ __launch_bounds__(10) void _occa_hello_0() {
   {


### PR DESCRIPTION
Always call implicit handle (even if there are attributes). 
Make global function handle skip @kernel
Should fix second part of https://github.com/libocca/occa-transpiler/issues/175 