### PR TITLE
Fix @restrict handle for dpcpp backend. Add more restrict tests

### DIFF
--- a/lib/attributes/backend/dpcpp/restrict.cpp
+++ b/lib/attributes/backend/dpcpp/restrict.cpp
@@ -10,37 +10,14 @@
 namespace {
 using namespace oklt;
 using namespace clang;
-const std::string RESTRICT_MODIFIER = "__restrict__";
+const std::string RESTRICT_MODIFIER = "__restrict__ ";
 
 HandleResult handleRestrictAttribute(const clang::Attr& a,
                                      const clang::Decl& decl,
                                      SessionStage& s) {
     SPDLOG_DEBUG("Handle [@restrict] attribute");
-
-    SourceLocation identifierLoc = decl.getLocation();
-    std::string restrictText = " " + RESTRICT_MODIFIER + " ";
-
-    // INFO: might be better to use rewriter.getRewrittenText() method
-
-    auto& ctx = decl.getASTContext();
-    SourceRange r1(decl.getSourceRange().getBegin(), identifierLoc);
-    auto part1 = getSourceText(r1, ctx);
-
-    auto ident = [](const clang::Decl& decl) {
-        switch (decl.getKind()) {
-            case Decl::Field:
-                return cast<FieldDecl>(decl).getNameAsString();
-            case Decl::ParmVar:
-                return cast<ParmVarDecl>(decl).getQualifiedNameAsString();
-            default:
-                return cast<VarDecl>(decl).getQualifiedNameAsString();
-        }
-    }(decl);
-
-    std::string modifiedArgument = part1 + restrictText + ident;
-
-    s.getRewriter().ReplaceText({getAttrFullSourceRange(a).getBegin(), decl.getEndLoc()},
-                                part1 + restrictText + ident);
+    removeAttribute(a, s);
+    s.getRewriter().InsertTextBefore(decl.getLocation(), RESTRICT_MODIFIER);
     return {};
 }
 

--- a/tests/functional/configs/test_suite_transpiler/backends/dpcpp/restrict.json
+++ b/tests/functional/configs/test_suite_transpiler/backends/dpcpp/restrict.json
@@ -31,6 +31,17 @@
             "launcher": ""
         },
         "reference": "transpiler/backends/dpcpp/restrict/restrict_namespaced_types_ref.cpp"
+     },
+     {
+        "action": "normalize_and_transpile",
+        "action_config": {
+            "backend": "dpcpp",
+            "source": "transpiler/backends/dpcpp/restrict/restrict_return_type.cpp",
+            "includes": [],
+            "defs": [],
+            "launcher": ""
+        },
+        "reference": "transpiler/backends/dpcpp/restrict/restrict_return_type_ref.cpp"
      }
 
 ]

--- a/tests/functional/configs/test_suite_transpiler/backends/hip/restrict.json
+++ b/tests/functional/configs/test_suite_transpiler/backends/hip/restrict.json
@@ -1,0 +1,47 @@
+[
+    {
+        "action": "normalize_and_transpile",
+        "action_config": {
+            "backend": "hip",
+            "source": "transpiler/backends/hip/restrict/restrict_builtin_types.cpp",
+            "includes": [],
+            "defs": [],
+            "launcher": ""
+        },
+        "reference": "transpiler/backends/hip/restrict/restrict_builtin_types_ref.cpp"
+     },
+     {
+        "action": "normalize_and_transpile",
+        "action_config": {
+            "backend": "hip",
+            "source": "transpiler/backends/hip/restrict/restrict_complex_types.cpp",
+            "includes": [],
+            "defs": [],
+            "launcher": ""
+        },
+        "reference": "transpiler/backends/hip/restrict/restrict_complex_types_ref.cpp"
+     },
+     {
+        "action": "normalize_and_transpile",
+        "action_config": {
+            "backend": "hip",
+            "source": "transpiler/backends/hip/restrict/restrict_namespaced_types.cpp",
+            "includes": [],
+            "defs": [],
+            "launcher": ""
+        },
+        "reference": "transpiler/backends/hip/restrict/restrict_namespaced_types_ref.cpp"
+     },
+     {
+        "action": "normalize_and_transpile",
+        "action_config": {
+            "backend": "hip",
+            "source": "transpiler/backends/hip/restrict/restrict_return_type.cpp",
+            "includes": [],
+            "defs": [],
+            "launcher": ""
+        },
+        "reference": "transpiler/backends/hip/restrict/restrict_return_type_ref.cpp"
+     }
+
+]

--- a/tests/functional/configs/test_suite_transpiler/backends/hip/suite.json
+++ b/tests/functional/configs/test_suite_transpiler/backends/hip/suite.json
@@ -7,5 +7,6 @@
     "inner_outer.json",
     "barrier.json",
     "nobarrier.json",
-    "macro.json"
+    "macro.json",
+    "restrict.json"
 ]

--- a/tests/functional/configs/test_suite_transpiler/backends/openmp/restrict.json
+++ b/tests/functional/configs/test_suite_transpiler/backends/openmp/restrict.json
@@ -31,5 +31,16 @@
       "launcher": ""
     },
     "reference": "transpiler/backends/openmp/restrict/restrict_namespaced_types_ref.cpp"
+  },
+  {
+    "action": "normalize_and_transpile",
+    "action_config": {
+      "backend": "openmp",
+      "source": "transpiler/backends/openmp/restrict/restrict_return_type.cpp",
+      "includes": [],
+      "defs": [],
+      "launcher": ""
+    },
+    "reference": "transpiler/backends/openmp/restrict/restrict_return_type_ref.cpp"
   }
 ]

--- a/tests/functional/configs/test_suite_transpiler/backends/serial/restrict.json
+++ b/tests/functional/configs/test_suite_transpiler/backends/serial/restrict.json
@@ -31,5 +31,16 @@
       "launcher": ""
     },
     "reference": "transpiler/backends/serial/restrict/restrict_namespaced_types_ref.cpp"
+  },
+  {
+    "action": "normalize_and_transpile",
+    "action_config": {
+      "backend": "serial",
+      "source": "transpiler/backends/serial/restrict/restrict_return_type.cpp",
+      "includes": [],
+      "defs": [],
+      "launcher": ""
+    },
+    "reference": "transpiler/backends/serial/restrict/restrict_return_type_ref.cpp"
   }
 ]

--- a/tests/functional/data/transpiler/backends/dpcpp/restrict/restrict_return_type.cpp
+++ b/tests/functional/data/transpiler/backends/dpcpp/restrict/restrict_return_type.cpp
@@ -1,0 +1,15 @@
+float* @restrict myfn(float* a) {
+    return a + 1;
+}
+
+float* myfn2(float* a) {
+    return a + 1;
+}
+
+@kernel void hello() {
+    for (int i = 0; i < 10; i++; @outer) {
+        for (int j = 0; j < 10; j++; @inner) {
+
+        }
+    }
+}

--- a/tests/functional/data/transpiler/backends/dpcpp/restrict/restrict_return_type_ref.cpp
+++ b/tests/functional/data/transpiler/backends/dpcpp/restrict/restrict_return_type_ref.cpp
@@ -1,0 +1,18 @@
+#include <CL/sycl.hpp>
+using namespace sycl;
+
+SYCL_EXTERNAL float *__restrict__ myfn(float *a) { return a + 1; }
+
+SYCL_EXTERNAL float *myfn2(float *a) { return a + 1; }
+
+extern "C" [[sycl::reqd_work_group_size(1, 1, 10)]] void
+_occa_hello_0(sycl::queue *queue_, sycl::nd_range<3> *range_) {
+  queue_->submit([&](sycl::handler &handler_) {
+    handler_.parallel_for(*range_, [=](sycl::nd_item<3> item_) {
+      {
+        int i = (0) + item_.get_group(2);
+        { int j = (0) + item.get_local_id(2); }
+      }
+    });
+  });
+}

--- a/tests/functional/data/transpiler/backends/hip/restrict/restrict_builtin_types.cpp
+++ b/tests/functional/data/transpiler/backends/hip/restrict/restrict_builtin_types.cpp
@@ -1,0 +1,11 @@
+
+
+@kernel void function1(const int* i32Data @restrict,
+                       float* fp32Data @restrict,
+                       const double* fp64Data @restrict) {
+    @outer for (int i = 0; i < 1; ++i) {
+        @inner for (int j = 0; j < 1; ++j) {
+            @restrict float* b = &fp32Data[0];
+        }
+    }
+}

--- a/tests/functional/data/transpiler/backends/hip/restrict/restrict_builtin_types_ref.cpp
+++ b/tests/functional/data/transpiler/backends/hip/restrict/restrict_builtin_types_ref.cpp
@@ -1,0 +1,13 @@
+#include <hip/hip_runtime.h>
+
+extern "C" __global__ __launch_bounds__(1) void _occa_function1_0(
+    const int *__restrict__ i32Data, float *__restrict__ fp32Data,
+    const double *__restrict__ fp64Data) {
+  {
+    int i = (0) + blockIdx.x;
+    {
+      int j = (0) + threadIdx.x;
+      float *__restrict__ b = &fp32Data[0];
+    }
+  }
+}

--- a/tests/functional/data/transpiler/backends/hip/restrict/restrict_complex_types.cpp
+++ b/tests/functional/data/transpiler/backends/hip/restrict/restrict_complex_types.cpp
@@ -1,0 +1,28 @@
+
+template <class T>
+struct Complex {
+    T real;
+    T imaginary;
+};
+
+struct Configs {
+    unsigned int size1;
+    unsigned long size2;
+};
+
+struct Data {
+    @restrict float* x;
+    @restrict float* y;
+    unsigned long size;
+};
+
+
+@kernel void function1(const Complex<float>* vectorData @restrict,
+                       unsigned int vectorSize,
+                       const Complex<float>** matricesData @restrict,
+                       const Configs* matricesSizes @restrict) {
+    @outer for (int i = 0; i < 1; ++i) {
+        @inner for (int j = 0; j < 1; ++j) {
+        }
+    }
+}

--- a/tests/functional/data/transpiler/backends/hip/restrict/restrict_complex_types_ref.cpp
+++ b/tests/functional/data/transpiler/backends/hip/restrict/restrict_complex_types_ref.cpp
@@ -1,0 +1,27 @@
+#include <hip/hip_runtime.h>
+
+template <class T> struct Complex {
+  T real;
+  T imaginary;
+};
+
+struct Configs {
+  unsigned int size1;
+  unsigned long size2;
+};
+
+struct Data {
+  float *__restrict__ x;
+  float *__restrict__ y;
+  unsigned long size;
+};
+
+extern "C" __global__ __launch_bounds__(1) void _occa_function1_0(
+    const Complex<float> *__restrict__ vectorData, unsigned int vectorSize,
+    const Complex<float> **__restrict__ matricesData,
+    const Configs *__restrict__ matricesSizes) {
+  {
+    int i = (0) + blockIdx.x;
+    { int j = (0) + threadIdx.x; }
+  }
+}

--- a/tests/functional/data/transpiler/backends/hip/restrict/restrict_namespaced_types.cpp
+++ b/tests/functional/data/transpiler/backends/hip/restrict/restrict_namespaced_types.cpp
@@ -1,0 +1,40 @@
+
+namespace A {
+template <class T>
+struct Complex {
+    T real;
+    T imaginary;
+};
+
+namespace B {
+struct Configs {
+    unsigned int size1;
+    unsigned long size2;
+};
+namespace C {
+typedef int SIZE_TYPE;
+typedef SIZE_TYPE SIZES;
+}  // namespace C
+}  // namespace B
+}  // namespace A
+
+
+@kernel void function1(const A::Complex<float>* vectorData @restrict,
+                       unsigned int vectorSize,
+                       const A::Complex<float>** matricesData @restrict,
+                       const A::B::Configs* matricesSizes @restrict) {
+    @outer for (int i = 0; i < 1; ++i) {
+        @inner for (int j = 0; j < 1; ++j) {
+        }
+    }
+}
+
+
+@kernel void function2(const A::Complex<float>* vectorData @restrict,
+                       const A::B::Configs* configs @restrict,
+                       A::B::C::SIZES* vectorSize @restrict) {
+    @outer for (int i = 0; i < 1; ++i) {
+        @inner for (int j = 0; j < 1; ++j) {
+        }
+    }
+}

--- a/tests/functional/data/transpiler/backends/hip/restrict/restrict_namespaced_types_ref.cpp
+++ b/tests/functional/data/transpiler/backends/hip/restrict/restrict_namespaced_types_ref.cpp
@@ -1,0 +1,40 @@
+#include <hip/hip_runtime.h>
+
+namespace A {
+template <class T> struct Complex {
+  T real;
+  T imaginary;
+};
+
+namespace B {
+struct Configs {
+  unsigned int size1;
+  unsigned long size2;
+};
+
+namespace C {
+typedef int SIZE_TYPE;
+typedef SIZE_TYPE SIZES;
+} // namespace C
+} // namespace B
+} // namespace A
+
+extern "C" __global__ __launch_bounds__(1) void _occa_function1_0(
+    const A::Complex<float> *__restrict__ vectorData, unsigned int vectorSize,
+    const A::Complex<float> **__restrict__ matricesData,
+    const A::B::Configs *__restrict__ matricesSizes) {
+  {
+    int i = (0) + blockIdx.x;
+    { int j = (0) + threadIdx.x; }
+  }
+}
+
+extern "C" __global__ __launch_bounds__(1) void _occa_function2_0(
+    const A::Complex<float> *__restrict__ vectorData,
+    const A::B::Configs *__restrict__ configs,
+    A::B::C::SIZES *__restrict__ vectorSize) {
+  {
+    int i = (0) + blockIdx.x;
+    { int j = (0) + threadIdx.x; }
+  }
+}

--- a/tests/functional/data/transpiler/backends/hip/restrict/restrict_return_type.cpp
+++ b/tests/functional/data/transpiler/backends/hip/restrict/restrict_return_type.cpp
@@ -1,0 +1,15 @@
+float* @restrict myfn(float* a) {
+    return a + 1;
+}
+
+float* myfn2(float* a) {
+    return a + 1;
+}
+
+@kernel void hello() {
+    for (int i = 0; i < 10; i++; @outer) {
+        for (int j = 0; j < 10; j++; @inner) {
+
+        }
+    }
+}

--- a/tests/functional/data/transpiler/backends/hip/restrict/restrict_return_type_ref.cpp
+++ b/tests/functional/data/transpiler/backends/hip/restrict/restrict_return_type_ref.cpp
@@ -1,0 +1,12 @@
+#include <hip/hip_runtime.h>
+
+__device__ float *__restrict__ myfn(float *a) { return a + 1; }
+
+__device__ float *myfn2(float *a) { return a + 1; }
+
+extern "C" __global__ __launch_bounds__(10) void _occa_hello_0() {
+  {
+    int i = (0) + blockIdx.x;
+    { int j = (0) + threadIdx.x; }
+  }
+}

--- a/tests/functional/data/transpiler/backends/openmp/restrict/restrict_return_type.cpp
+++ b/tests/functional/data/transpiler/backends/openmp/restrict/restrict_return_type.cpp
@@ -1,0 +1,15 @@
+float* @restrict myfn(float* a) {
+    return a + 1;
+}
+
+float* myfn2(float* a) {
+    return a + 1;
+}
+
+@kernel void hello() {
+    for (int i = 0; i < 10; i++; @outer) {
+        for (int j = 0; j < 10; j++; @inner) {
+
+        }
+    }
+}

--- a/tests/functional/data/transpiler/backends/openmp/restrict/restrict_return_type_ref.cpp
+++ b/tests/functional/data/transpiler/backends/openmp/restrict/restrict_return_type_ref.cpp
@@ -1,0 +1,11 @@
+float *__restrict__ myfn(float *a) { return a + 1; }
+
+float *myfn2(float *a) { return a + 1; }
+
+extern "C" void hello() {
+#pragma omp parallel for
+  for (int i = 0; i < 10; i++) {
+    for (int j = 0; j < 10; j++) {
+    }
+  }
+}

--- a/tests/functional/data/transpiler/backends/serial/restrict/restrict_return_type.cpp
+++ b/tests/functional/data/transpiler/backends/serial/restrict/restrict_return_type.cpp
@@ -1,0 +1,15 @@
+float* @restrict myfn(float* a) {
+    return a + 1;
+}
+
+float* myfn2(float* a) {
+    return a + 1;
+}
+
+@kernel void hello() {
+    for (int i = 0; i < 10; i++; @outer) {
+        for (int j = 0; j < 10; j++; @inner) {
+
+        }
+    }
+}

--- a/tests/functional/data/transpiler/backends/serial/restrict/restrict_return_type_ref.cpp
+++ b/tests/functional/data/transpiler/backends/serial/restrict/restrict_return_type_ref.cpp
@@ -1,0 +1,10 @@
+float *__restrict__ myfn(float *a) { return a + 1; }
+
+float *myfn2(float *a) { return a + 1; }
+
+extern "C" void hello() {
+  for (int i = 0; i < 10; i++) {
+    for (int j = 0; j < 10; j++) {
+    }
+  }
+}


### PR DESCRIPTION
Fix the restrict handle for dpcpp to make it work with the function return type. Also, add more restrict tests for hip and dpcpp backends