### PR TITLE
Friendzone all `register` methods to avoid linkage problems.

### DIFF
--- a/lib/attributes/backend/common/dim.cpp
+++ b/lib/attributes/backend/common/dim.cpp
@@ -198,12 +198,12 @@ HandleResult handleDimStmtAttribute(SessionStage& stage,
 }
 
 __attribute__((constructor)) void registerAttrBackend() {
-    auto ok = HandlerManager::registerCommonHandler(DIM_ATTR_NAME, handleDimDeclAttribute);
+    auto ok = registerCommonHandler(DIM_ATTR_NAME, handleDimDeclAttribute);
     if (!ok) {
         SPDLOG_ERROR("Failed to register {} attribute decl handler", DIM_ATTR_NAME);
     }
 
-    ok = HandlerManager::registerCommonHandler(DIM_ATTR_NAME, handleDimStmtAttribute);
+    ok = registerCommonHandler(DIM_ATTR_NAME, handleDimStmtAttribute);
     if (!ok) {
         SPDLOG_ERROR("Failed to register {} attribute stmt handler", DIM_ATTR_NAME);
     }

--- a/lib/attributes/backend/common/dim_order.cpp
+++ b/lib/attributes/backend/common/dim_order.cpp
@@ -31,11 +31,9 @@ HandleResult handleDimOrderStmtAttribute(SessionStage& s,
 }
 
 __attribute__((constructor)) void registerAttrBackend() {
-    auto ok =
-        HandlerManager::registerCommonHandler(DIM_ORDER_ATTR_NAME, handleDimOrderDeclAttribute);
+    auto ok = registerCommonHandler(DIM_ORDER_ATTR_NAME, handleDimOrderDeclAttribute);
 
-    ok = ok &&
-         HandlerManager::registerCommonHandler(DIM_ORDER_ATTR_NAME, handleDimOrderStmtAttribute);
+    ok = ok && registerCommonHandler(DIM_ORDER_ATTR_NAME, handleDimOrderStmtAttribute);
     if (!ok) {
         SPDLOG_ERROR("Failed to register {} attribute stmt handler", DIM_ORDER_ATTR_NAME);
     }

--- a/lib/attributes/backend/common/max_inner_dims.cpp
+++ b/lib/attributes/backend/common/max_inner_dims.cpp
@@ -42,8 +42,7 @@ HandleResult handleMaxInnerDimsStmtAttribute(SessionStage& s,
 }
 
 __attribute__((constructor)) void registerAttrBackend() {
-    auto ok =
-        HandlerManager::registerCommonHandler(MAX_INNER_DIMS, handleMaxInnerDimsStmtAttribute);
+    auto ok = registerCommonHandler(MAX_INNER_DIMS, handleMaxInnerDimsStmtAttribute);
 
     if (!ok) {
         SPDLOG_ERROR("Failed to register {} attribute handler", MAX_INNER_DIMS);

--- a/lib/attributes/backend/common/no_barrier.cpp
+++ b/lib/attributes/backend/common/no_barrier.cpp
@@ -28,8 +28,7 @@ HandleResult handleNoBarrierStmtAttribute(SessionStage& s,
 }
 
 __attribute__((constructor)) void registerAttrBackend() {
-    auto ok =
-        HandlerManager::registerCommonHandler(NO_BARRIER_ATTR_NAME, handleNoBarrierStmtAttribute);
+    auto ok = registerCommonHandler(NO_BARRIER_ATTR_NAME, handleNoBarrierStmtAttribute);
 
     if (!ok) {
         SPDLOG_ERROR("Failed to register {} attribute handler", NO_BARRIER_ATTR_NAME);

--- a/lib/attributes/backend/cuda/atomic.cpp
+++ b/lib/attributes/backend/cuda/atomic.cpp
@@ -9,7 +9,7 @@ using namespace oklt;
 using namespace clang;
 
 __attribute__((constructor)) void registerAttrBackend() {
-    auto ok = HandlerManager::registerBackendHandler(
+    auto ok = registerBackendHandler(
         TargetBackend::CUDA, ATOMIC_ATTR_NAME, cuda_subset::handleAtomicAttribute);
 
     if (!ok) {

--- a/lib/attributes/backend/cuda/barrier.cpp
+++ b/lib/attributes/backend/cuda/barrier.cpp
@@ -9,7 +9,7 @@ using namespace oklt;
 using namespace clang;
 
 __attribute__((constructor)) void registerCUDABarrierAttrBackend() {
-    auto ok = HandlerManager::registerBackendHandler(
+    auto ok = registerBackendHandler(
         TargetBackend::CUDA, BARRIER_ATTR_NAME, cuda_subset::handleBarrierAttribute);
 
     if (!ok) {

--- a/lib/attributes/backend/cuda/cxx_record.cpp
+++ b/lib/attributes/backend/cuda/cxx_record.cpp
@@ -28,11 +28,11 @@ HandleResult handleClassTemplatePartialSpecialization(
 }
 
 __attribute__((constructor)) void registerAttrBackend() {
-    auto ok = HandlerManager::registerImplicitHandler(TargetBackend::CUDA, handleClassRecord);
+    auto ok = registerImplicitHandler(TargetBackend::CUDA, handleClassRecord);
 
-    ok &= HandlerManager::registerImplicitHandler(TargetBackend::CUDA, handleClassTemplateSpecialization);
+    ok &= registerImplicitHandler(TargetBackend::CUDA, handleClassTemplateSpecialization);
 
-    ok &= HandlerManager::registerImplicitHandler(TargetBackend::CUDA, handleClassTemplatePartialSpecialization);
+    ok &= registerImplicitHandler(TargetBackend::CUDA, handleClassTemplatePartialSpecialization);
 
     if (!ok) {
         SPDLOG_ERROR("[CUDA] Failed to register implicit handler for global function");

--- a/lib/attributes/backend/cuda/exclusive.cpp
+++ b/lib/attributes/backend/cuda/exclusive.cpp
@@ -10,9 +10,9 @@ using namespace oklt;
 using namespace clang;
 
 __attribute__((constructor)) void registerCUDAExclusiveAttrBackend() {
-    auto ok = HandlerManager::registerBackendHandler(
+    auto ok = registerBackendHandler(
         TargetBackend::CUDA, EXCLUSIVE_ATTR_NAME, cuda_subset::handleExclusiveAttribute);
-    ok &= HandlerManager::registerBackendHandler(
+    ok &= registerBackendHandler(
         TargetBackend::CUDA, EXCLUSIVE_ATTR_NAME, defaultHandleSharedStmtAttribute);
 
     if (!ok) {

--- a/lib/attributes/backend/cuda/global_constant.cpp
+++ b/lib/attributes/backend/cuda/global_constant.cpp
@@ -13,7 +13,7 @@ HandleResult handleGlobalConstant(oklt::SessionStage& s, const clang::VarDecl& d
 }
 
 __attribute__((constructor)) void registeCUDAGlobalConstantHandler() {
-    auto ok = HandlerManager::registerImplicitHandler(TargetBackend::CUDA, handleGlobalConstant);
+    auto ok = registerImplicitHandler(TargetBackend::CUDA, handleGlobalConstant);
 
     if (!ok) {
         SPDLOG_ERROR("[CUDA] Failed to register implicit handler for global constant");

--- a/lib/attributes/backend/cuda/global_function.cpp
+++ b/lib/attributes/backend/cuda/global_function.cpp
@@ -15,8 +15,7 @@ HandleResult handleCudaGlobalFunction(SessionStage& s, const clang::FunctionDecl
 }
 
 __attribute__((constructor)) void registerAttrBackend() {
-    auto ok =
-        HandlerManager::registerImplicitHandler(TargetBackend::CUDA, handleCudaGlobalFunction);
+    auto ok = registerImplicitHandler(TargetBackend::CUDA, handleCudaGlobalFunction);
 
     if (!ok) {
         SPDLOG_ERROR("[CUDA] Failed to register implicit handler for global function");

--- a/lib/attributes/backend/cuda/inner.cpp
+++ b/lib/attributes/backend/cuda/inner.cpp
@@ -9,7 +9,7 @@ using namespace oklt;
 using namespace clang;
 
 __attribute__((constructor)) void registerBackendHandler() {
-    auto ok = HandlerManager::registerBackendHandler(
+    auto ok = registerBackendHandler(
         TargetBackend::CUDA, INNER_ATTR_NAME, cuda_subset::handleInnerAttribute);
 
     if (!ok) {

--- a/lib/attributes/backend/cuda/kernel.cpp
+++ b/lib/attributes/backend/cuda/kernel.cpp
@@ -9,7 +9,7 @@ using namespace oklt;
 using namespace clang;
 
 __attribute__((constructor)) void registerAttrBackend() {
-    auto ok = HandlerManager::registerBackendHandler(
+    auto ok = registerBackendHandler(
         TargetBackend::CUDA, KERNEL_ATTR_NAME, cuda_subset::handleKernelAttribute);
 
     if (!ok) {

--- a/lib/attributes/backend/cuda/outer.cpp
+++ b/lib/attributes/backend/cuda/outer.cpp
@@ -9,7 +9,7 @@ using namespace oklt;
 using namespace clang;
 
 __attribute__((constructor)) void registerBackendHandler() {
-    auto ok = HandlerManager::registerBackendHandler(
+    auto ok = registerBackendHandler(
         TargetBackend::CUDA, OUTER_ATTR_NAME, cuda_subset::handleOuterAttribute);
 
     if (!ok) {

--- a/lib/attributes/backend/cuda/restrict.cpp
+++ b/lib/attributes/backend/cuda/restrict.cpp
@@ -9,7 +9,7 @@ using namespace oklt;
 using namespace clang;
 
 __attribute__((constructor)) void registerCUDARestrictHandler() {
-    auto ok = HandlerManager::registerBackendHandler(
+    auto ok = registerBackendHandler(
         TargetBackend::CUDA, RESTRICT_ATTR_NAME, cuda_subset::handleRestrictAttribute);
 
     if (!ok) {

--- a/lib/attributes/backend/cuda/shared.cpp
+++ b/lib/attributes/backend/cuda/shared.cpp
@@ -10,11 +10,11 @@ using namespace oklt;
 using namespace clang;
 
 __attribute__((constructor)) void registerCUDASharedAttrBackend() {
-    auto ok = HandlerManager::registerBackendHandler(
+    auto ok = registerBackendHandler(
         TargetBackend::CUDA, SHARED_ATTR_NAME, cuda_subset::handleSharedAttribute);
 
     // Empty Stmt handler since @shared variable is of attributed type, it is called on DeclRefExpr
-    ok &= HandlerManager::registerBackendHandler(
+    ok &= registerBackendHandler(
         TargetBackend::CUDA, SHARED_ATTR_NAME, defaultHandleSharedStmtAttribute);
 
     if (!ok) {

--- a/lib/attributes/backend/cuda/tile.cpp
+++ b/lib/attributes/backend/cuda/tile.cpp
@@ -9,7 +9,7 @@ using namespace oklt;
 using namespace clang;
 
 __attribute__((constructor)) void registerHIPTileAttrBackend() {
-    auto ok = HandlerManager::registerBackendHandler(
+    auto ok = registerBackendHandler(
         TargetBackend::CUDA, TILE_ATTR_NAME, cuda_subset::handleTileAttribute);
 
     if (!ok) {

--- a/lib/attributes/backend/cuda/translation_unit.cpp
+++ b/lib/attributes/backend/cuda/translation_unit.cpp
@@ -27,7 +27,7 @@ HandleResult handleTranslationUnit(SessionStage& s, const TranslationUnitDecl& d
 }
 
 __attribute__((constructor)) void registerAttrBackend() {
-    auto ok = HandlerManager::registerImplicitHandler(TargetBackend::CUDA, handleTranslationUnit);
+    auto ok = registerImplicitHandler(TargetBackend::CUDA, handleTranslationUnit);
     if (!ok) {
         SPDLOG_ERROR("[CUDA] Failed to register implicit handler for translation unit");
     }

--- a/lib/attributes/backend/dpcpp/atomic.cpp
+++ b/lib/attributes/backend/dpcpp/atomic.cpp
@@ -107,8 +107,7 @@ HandleResult handleAtomicAttribute(SessionStage& stage,
 }
 
 __attribute__((constructor)) void registerAttrBackend() {
-    auto ok = HandlerManager::registerBackendHandler(
-        TargetBackend::DPCPP, ATOMIC_ATTR_NAME, handleAtomicAttribute);
+    auto ok = registerBackendHandler(TargetBackend::DPCPP, ATOMIC_ATTR_NAME, handleAtomicAttribute);
 
     if (!ok) {
         SPDLOG_ERROR("[DPCPP] Failed to register {} attribute handler", ATOMIC_ATTR_NAME);

--- a/lib/attributes/backend/dpcpp/barrier.cpp
+++ b/lib/attributes/backend/dpcpp/barrier.cpp
@@ -23,8 +23,8 @@ HandleResult handleBarrierAttribute(SessionStage& s,
 }
 
 __attribute__((constructor)) void registerAttrBackend() {
-    auto ok = HandlerManager::registerBackendHandler(
-        TargetBackend::DPCPP, BARRIER_ATTR_NAME, handleBarrierAttribute);
+    auto ok =
+        registerBackendHandler(TargetBackend::DPCPP, BARRIER_ATTR_NAME, handleBarrierAttribute);
 
     if (!ok) {
         SPDLOG_ERROR("[DPCPP] Failed to register {} attribute handler", BARRIER_ATTR_NAME);

--- a/lib/attributes/backend/dpcpp/exclusive.cpp
+++ b/lib/attributes/backend/dpcpp/exclusive.cpp
@@ -20,10 +20,10 @@ HandleResult handleExclusiveAttribute(SessionStage& s,
 }
 
 __attribute__((constructor)) void registerAttrBackend() {
-    auto ok = HandlerManager::registerBackendHandler(
-        TargetBackend::DPCPP, EXCLUSIVE_ATTR_NAME, handleExclusiveAttribute);
+    auto ok =
+        registerBackendHandler(TargetBackend::DPCPP, EXCLUSIVE_ATTR_NAME, handleExclusiveAttribute);
 
-    ok &= HandlerManager::registerBackendHandler(
+    ok &= registerBackendHandler(
         TargetBackend::DPCPP, EXCLUSIVE_ATTR_NAME, defaultHandleExclusiveStmtAttribute);
 
     if (!ok) {

--- a/lib/attributes/backend/dpcpp/global_function.cpp
+++ b/lib/attributes/backend/dpcpp/global_function.cpp
@@ -13,8 +13,7 @@ HandleResult handleGlobalFunctionDpcpp(oklt::SessionStage& s, const clang::Funct
 }
 
 __attribute__((constructor)) void registerTranslationUnitAttrBackend() {
-    auto ok =
-        HandlerManager::registerImplicitHandler(TargetBackend::DPCPP, handleGlobalFunctionDpcpp);
+    auto ok = registerImplicitHandler(TargetBackend::DPCPP, handleGlobalFunctionDpcpp);
 
     if (!ok) {
         SPDLOG_ERROR("[DPCPP] Failed to register implicit handler for global function");

--- a/lib/attributes/backend/dpcpp/inner.cpp
+++ b/lib/attributes/backend/dpcpp/inner.cpp
@@ -47,8 +47,7 @@ HandleResult handleInnerAttribute(SessionStage& s,
 }
 
 __attribute__((constructor)) void registerDpppInnerAttrBackend() {
-    auto ok = HandlerManager::registerBackendHandler(
-        TargetBackend::DPCPP, INNER_ATTR_NAME, handleInnerAttribute);
+    auto ok = registerBackendHandler(TargetBackend::DPCPP, INNER_ATTR_NAME, handleInnerAttribute);
 
     if (!ok) {
         SPDLOG_ERROR("[DPCPP] Failed to register {} attribute handler", INNER_ATTR_NAME);

--- a/lib/attributes/backend/dpcpp/kernel.cpp
+++ b/lib/attributes/backend/dpcpp/kernel.cpp
@@ -157,8 +157,7 @@ HandleResult handleKernelAttribute(SessionStage& s,
 }
 
 __attribute__((constructor)) void registerKernelHandler() {
-    auto ok = HandlerManager::registerBackendHandler(
-        TargetBackend::DPCPP, KERNEL_ATTR_NAME, handleKernelAttribute);
+    auto ok = registerBackendHandler(TargetBackend::DPCPP, KERNEL_ATTR_NAME, handleKernelAttribute);
 
     if (!ok) {
         SPDLOG_ERROR("[DPCPP] Failed to register {} attribute handler", KERNEL_ATTR_NAME);

--- a/lib/attributes/backend/dpcpp/outer.cpp
+++ b/lib/attributes/backend/dpcpp/outer.cpp
@@ -40,8 +40,7 @@ HandleResult handleOuterAttribute(SessionStage& s,
 }
 
 __attribute__((constructor)) void registerDpcppOuterAttrBackend() {
-    auto ok = HandlerManager::registerBackendHandler(
-        TargetBackend::DPCPP, OUTER_ATTR_NAME, handleOuterAttribute);
+    auto ok = registerBackendHandler(TargetBackend::DPCPP, OUTER_ATTR_NAME, handleOuterAttribute);
 
     if (!ok) {
         SPDLOG_ERROR("[DPCPP] Failed to register {} attribute handler", OUTER_ATTR_NAME);

--- a/lib/attributes/backend/dpcpp/restrict.cpp
+++ b/lib/attributes/backend/dpcpp/restrict.cpp
@@ -22,8 +22,8 @@ HandleResult handleRestrictAttribute(SessionStage& s,
 }
 
 __attribute__((constructor)) void registerCUDARestrictHandler() {
-    auto ok = HandlerManager::registerBackendHandler(
-        TargetBackend::DPCPP, RESTRICT_ATTR_NAME, handleRestrictAttribute);
+    auto ok =
+        registerBackendHandler(TargetBackend::DPCPP, RESTRICT_ATTR_NAME, handleRestrictAttribute);
 
     if (!ok) {
         SPDLOG_ERROR("[DPCPP] Failed to register {} attribute handler", RESTRICT_ATTR_NAME);

--- a/lib/attributes/backend/dpcpp/shared.cpp
+++ b/lib/attributes/backend/dpcpp/shared.cpp
@@ -47,11 +47,10 @@ HandleResult handleSharedAttribute(SessionStage& s, const VarDecl& var, const At
 }
 
 __attribute__((constructor)) void registerCUDASharedAttrBackend() {
-    auto ok = HandlerManager::registerBackendHandler(
-        TargetBackend::DPCPP, SHARED_ATTR_NAME, handleSharedAttribute);
+    auto ok = registerBackendHandler(TargetBackend::DPCPP, SHARED_ATTR_NAME, handleSharedAttribute);
 
     // Empty Stmt handler since @shared variable is of attributed type, it is called on DeclRefExpr
-    ok &= HandlerManager::registerBackendHandler(
+    ok &= registerBackendHandler(
         TargetBackend::DPCPP, SHARED_ATTR_NAME, defaultHandleSharedStmtAttribute);
 
     if (!ok) {

--- a/lib/attributes/backend/dpcpp/tile.cpp
+++ b/lib/attributes/backend/dpcpp/tile.cpp
@@ -258,8 +258,7 @@ HandleResult handleTileAttribute(SessionStage& s,
 }
 
 __attribute__((constructor)) void registerDpcppTileAttrBackend() {
-    auto ok = HandlerManager::registerBackendHandler(
-        TargetBackend::DPCPP, TILE_ATTR_NAME, handleTileAttribute);
+    auto ok = registerBackendHandler(TargetBackend::DPCPP, TILE_ATTR_NAME, handleTileAttribute);
 
     if (!ok) {
         SPDLOG_ERROR("[DPCPP] Failed to register {} attribute handler", TILE_ATTR_NAME);

--- a/lib/attributes/backend/dpcpp/translation_unit.cpp
+++ b/lib/attributes/backend/dpcpp/translation_unit.cpp
@@ -15,8 +15,7 @@ HandleResult handleTranslationUnitDpcpp(SessionStage& s, const clang::Translatio
 }
 
 __attribute__((constructor)) void registerTranslationUnitAttrBackend() {
-    auto ok =
-        HandlerManager::registerImplicitHandler(TargetBackend::DPCPP, handleTranslationUnitDpcpp);
+    auto ok = registerImplicitHandler(TargetBackend::DPCPP, handleTranslationUnitDpcpp);
 
     if (!ok) {
         SPDLOG_ERROR("[DPCPP] Failed to register implicit handler for translation unit");

--- a/lib/attributes/backend/hip/atomic.cpp
+++ b/lib/attributes/backend/hip/atomic.cpp
@@ -9,7 +9,7 @@ using namespace oklt;
 using namespace clang;
 
 __attribute__((constructor)) void registerAttrBackend() {
-    auto ok = HandlerManager::registerBackendHandler(
+    auto ok = registerBackendHandler(
         TargetBackend::HIP, ATOMIC_ATTR_NAME, cuda_subset::handleAtomicAttribute);
 
     if (!ok) {

--- a/lib/attributes/backend/hip/barrier.cpp
+++ b/lib/attributes/backend/hip/barrier.cpp
@@ -9,7 +9,7 @@ using namespace oklt;
 using namespace clang;
 
 __attribute__((constructor)) void registerHIPBarrierAttrBackend() {
-    auto ok = HandlerManager::registerBackendHandler(
+    auto ok = registerBackendHandler(
         TargetBackend::HIP, BARRIER_ATTR_NAME, cuda_subset::handleBarrierAttribute);
 
     if (!ok) {

--- a/lib/attributes/backend/hip/cxx_record.cpp
+++ b/lib/attributes/backend/hip/cxx_record.cpp
@@ -28,11 +28,11 @@ HandleResult handleClassTemplatePartialSpecialization(
 }
 
 __attribute__((constructor)) void registerAttrBackend() {
-    auto ok = HandlerManager::registerImplicitHandler(TargetBackend::HIP, handleClassRecord);
+    auto ok = registerImplicitHandler(TargetBackend::HIP, handleClassRecord);
 
-    ok &= HandlerManager::registerImplicitHandler(TargetBackend::HIP, handleClassTemplateSpecialization);
+    ok &= registerImplicitHandler(TargetBackend::HIP, handleClassTemplateSpecialization);
 
-    ok &= HandlerManager::registerImplicitHandler(TargetBackend::HIP, handleClassTemplatePartialSpecialization);
+    ok &= registerImplicitHandler(TargetBackend::HIP, handleClassTemplatePartialSpecialization);
 
     if (!ok) {
         SPDLOG_ERROR("[HIP] Failed to register implicit handler for global function");

--- a/lib/attributes/backend/hip/exclusive.cpp
+++ b/lib/attributes/backend/hip/exclusive.cpp
@@ -10,14 +10,14 @@ using namespace oklt;
 using namespace clang;
 
 __attribute__((constructor)) void registerHIPExclusiveAttrBackend() {
-    auto ok = HandlerManager::registerBackendHandler(
+    auto ok = registerBackendHandler(
         TargetBackend::HIP, EXCLUSIVE_ATTR_NAME, cuda_subset::handleExclusiveAttribute);
 
     if (!ok) {
         SPDLOG_ERROR("[HIP] Failed to register {} attribute handler", EXCLUSIVE_ATTR_NAME);
     }
 
-    ok = HandlerManager::registerBackendHandler(
+    ok = registerBackendHandler(
         TargetBackend::HIP, EXCLUSIVE_ATTR_NAME, defaultHandleExclusiveStmtAttribute);
 
     if (!ok) {

--- a/lib/attributes/backend/hip/global_constant.cpp
+++ b/lib/attributes/backend/hip/global_constant.cpp
@@ -12,7 +12,7 @@ HandleResult handleHIPGlobalConstant(oklt::SessionStage& s, const clang::VarDecl
 }
 
 __attribute__((constructor)) void registerHIPGlobalConstantHandler() {
-    auto ok = HandlerManager::registerImplicitHandler(TargetBackend::HIP, handleHIPGlobalConstant);
+    auto ok = registerImplicitHandler(TargetBackend::HIP, handleHIPGlobalConstant);
 
     if (!ok) {
         SPDLOG_ERROR("[HIP] Failed to register implicit handler for global constant");

--- a/lib/attributes/backend/hip/global_function.cpp
+++ b/lib/attributes/backend/hip/global_function.cpp
@@ -13,7 +13,7 @@ HandleResult handleHIPGlobalFunction(oklt::SessionStage& s, const clang::Functio
 }
 
 __attribute__((constructor)) void registerHIPKernelHandler() {
-    auto ok = HandlerManager::registerImplicitHandler(TargetBackend::HIP, handleHIPGlobalFunction);
+    auto ok = registerImplicitHandler(TargetBackend::HIP, handleHIPGlobalFunction);
 
     if (!ok) {
         SPDLOG_ERROR("[HIP] Failed to register implicit handler for global function");

--- a/lib/attributes/backend/hip/inner.cpp
+++ b/lib/attributes/backend/hip/inner.cpp
@@ -9,7 +9,7 @@ using namespace oklt;
 using namespace clang;
 
 __attribute__((constructor)) void registerHIPInnerAttrBackend() {
-    auto ok = HandlerManager::registerBackendHandler(
+    auto ok = registerBackendHandler(
         TargetBackend::HIP, INNER_ATTR_NAME, cuda_subset::handleInnerAttribute);
 
     if (!ok) {

--- a/lib/attributes/backend/hip/kernel.cpp
+++ b/lib/attributes/backend/hip/kernel.cpp
@@ -9,7 +9,7 @@ using namespace oklt;
 using namespace clang;
 
 __attribute__((constructor)) void registerKernelHandler() {
-    auto ok = HandlerManager::registerBackendHandler(
+    auto ok = registerBackendHandler(
         TargetBackend::HIP, KERNEL_ATTR_NAME, cuda_subset::handleKernelAttribute);
 
     if (!ok) {

--- a/lib/attributes/backend/hip/outer.cpp
+++ b/lib/attributes/backend/hip/outer.cpp
@@ -9,7 +9,7 @@ using namespace oklt;
 using namespace clang;
 
 __attribute__((constructor)) void registerHIPOuterAttrBackend() {
-    auto ok = HandlerManager::registerBackendHandler(
+    auto ok = registerBackendHandler(
         TargetBackend::HIP, OUTER_ATTR_NAME, cuda_subset::handleOuterAttribute);
 
     if (!ok) {

--- a/lib/attributes/backend/hip/restrict.cpp
+++ b/lib/attributes/backend/hip/restrict.cpp
@@ -9,7 +9,7 @@ using namespace oklt;
 using namespace clang;
 
 __attribute__((constructor)) void registerCUDARestrictHandler() {
-    auto ok = HandlerManager::registerBackendHandler(
+    auto ok = registerBackendHandler(
         TargetBackend::HIP, RESTRICT_ATTR_NAME, cuda_subset::handleRestrictAttribute);
 
     if (!ok) {

--- a/lib/attributes/backend/hip/shared.cpp
+++ b/lib/attributes/backend/hip/shared.cpp
@@ -10,11 +10,11 @@ using namespace oklt;
 using namespace clang;
 
 __attribute__((constructor)) void registerCUDASharedAttrBackend() {
-    auto ok = HandlerManager::registerBackendHandler(
+    auto ok = registerBackendHandler(
         TargetBackend::HIP, SHARED_ATTR_NAME, cuda_subset::handleSharedAttribute);
 
     // Empty Stmt handler since @shared variable is of attributed type, it is called on DeclRefExpr
-    ok &= HandlerManager::registerBackendHandler(
+    ok &= registerBackendHandler(
         TargetBackend::HIP, SHARED_ATTR_NAME, defaultHandleSharedStmtAttribute);
 
     if (!ok) {

--- a/lib/attributes/backend/hip/tile.cpp
+++ b/lib/attributes/backend/hip/tile.cpp
@@ -9,7 +9,7 @@ using namespace oklt;
 using namespace clang;
 
 __attribute__((constructor)) void registerHIPTileAttrBackend() {
-    auto ok = HandlerManager::registerBackendHandler(
+    auto ok = registerBackendHandler(
         TargetBackend::HIP, TILE_ATTR_NAME, cuda_subset::handleTileAttribute);
 
     if (!ok) {

--- a/lib/attributes/backend/hip/translation_unit.cpp
+++ b/lib/attributes/backend/hip/translation_unit.cpp
@@ -1,5 +1,5 @@
 #include "attributes/utils/replace_attribute.h"
-#include "core/handler_manager/parse_handler.h"
+#include "core/handler_manager/implicid_handler.h"
 
 #include <spdlog/spdlog.h>
 
@@ -17,7 +17,7 @@ HandleResult handleTU(SessionStage& s, const TranslationUnitDecl& d) {
 }
 
 __attribute__((constructor)) void registerAttrBackend() {
-    auto ok = HandlerManager::registerImplicitHandler(TargetBackend::HIP, handleTU);
+    auto ok = registerImplicitHandler(TargetBackend::HIP, handleTU);
 
     if (!ok) {
         SPDLOG_ERROR("[HIP] Failed to register implicit handler for translation unit");

--- a/lib/attributes/backend/launcher.cpp
+++ b/lib/attributes/backend/launcher.cpp
@@ -412,15 +412,14 @@ HandleResult handleLauncherKernelAttribute(SessionStage& s,
 
 __attribute__((constructor)) void registerLauncherHandler() {
 #define REG_ATTR_HANDLE(NAME, BODY)                                                   \
-    {                                                                                           \
-        auto ok = HandlerManager::registerBackendHandler(TargetBackend::_LAUNCHER, NAME, BODY);                                    \
+    {                                                                                 \
+        auto ok = registerBackendHandler(TargetBackend::_LAUNCHER, NAME, BODY);       \
         if (!ok) {                                                                    \
             SPDLOG_ERROR("Failed to register {} attribute handler (Launcher)", NAME); \
         }                                                                             \
     }
 
-    auto ok = HandlerManager::registerImplicitHandler(TargetBackend::_LAUNCHER,
-                                                      handleLauncherTranslationUnit);
+    auto ok = registerImplicitHandler(TargetBackend::_LAUNCHER, handleLauncherTranslationUnit);
 
     if (!ok) {
         SPDLOG_ERROR("Failed to register implicit handler for translation unit (Launcher)");

--- a/lib/attributes/backend/openmp/atomic.cpp
+++ b/lib/attributes/backend/openmp/atomic.cpp
@@ -28,7 +28,7 @@ HandleResult handleOPENMPAtomicAttribute(SessionStage& s, const Stmt& stmt, cons
 }
 
 __attribute__((constructor)) void registerOPENMPAtomicHandler() {
-    auto ok = HandlerManager::registerBackendHandler(
+    auto ok = registerBackendHandler(
         TargetBackend::OPENMP, ATOMIC_ATTR_NAME, handleOPENMPAtomicAttribute);
 
     if (!ok) {

--- a/lib/attributes/backend/openmp/barrier.cpp
+++ b/lib/attributes/backend/openmp/barrier.cpp
@@ -15,7 +15,7 @@ HandleResult handleOPENMPBarrierAttribute(SessionStage& s, const NullStmt& stmt,
 }
 
 __attribute__((constructor)) void registerOPENMPBarrierHandler() {
-    auto ok = HandlerManager::registerBackendHandler(
+    auto ok = registerBackendHandler(
         TargetBackend::OPENMP, BARRIER_ATTR_NAME, handleOPENMPBarrierAttribute);
 
     if (!ok) {

--- a/lib/attributes/backend/openmp/exclusive.cpp
+++ b/lib/attributes/backend/openmp/exclusive.cpp
@@ -9,9 +9,9 @@ using namespace oklt;
 using namespace clang;
 
 __attribute__((constructor)) void registerOPENMPExclusiveHandler() {
-    auto ok = HandlerManager::registerBackendHandler(
+    auto ok = registerBackendHandler(
         TargetBackend::OPENMP, EXCLUSIVE_ATTR_NAME, serial_subset::handleExclusiveExprAttribute);
-    ok &= HandlerManager::registerBackendHandler(
+    ok &= registerBackendHandler(
         TargetBackend::OPENMP, EXCLUSIVE_ATTR_NAME, serial_subset::handleExclusiveDeclAttribute);
 
     if (!ok) {

--- a/lib/attributes/backend/openmp/inner.cpp
+++ b/lib/attributes/backend/openmp/inner.cpp
@@ -7,7 +7,7 @@ using namespace oklt;
 using namespace clang;
 
 __attribute__((constructor)) void registerOPENMPOuterHandler() {
-    auto ok = HandlerManager::registerBackendHandler(
+    auto ok = registerBackendHandler(
         TargetBackend::OPENMP, INNER_ATTR_NAME, serial_subset::handleInnerAttribute);
 
     if (!ok) {

--- a/lib/attributes/backend/openmp/kernel.cpp
+++ b/lib/attributes/backend/openmp/kernel.cpp
@@ -7,7 +7,7 @@ using namespace oklt;
 using namespace clang;
 
 __attribute__((constructor)) void registerOPENMPKernelHandler() {
-    auto ok = HandlerManager::registerBackendHandler(
+    auto ok = registerBackendHandler(
         TargetBackend::OPENMP, KERNEL_ATTR_NAME, serial_subset::handleKernelAttribute);
 
     if (!ok) {

--- a/lib/attributes/backend/openmp/outer.cpp
+++ b/lib/attributes/backend/openmp/outer.cpp
@@ -28,8 +28,8 @@ HandleResult handleOPENMPOuterAttribute(SessionStage& s,
 }
 
 __attribute__((constructor)) void registerOPENMPOuterHandler() {
-    auto ok = HandlerManager::registerBackendHandler(
-        TargetBackend::OPENMP, OUTER_ATTR_NAME, handleOPENMPOuterAttribute);
+    auto ok =
+        registerBackendHandler(TargetBackend::OPENMP, OUTER_ATTR_NAME, handleOPENMPOuterAttribute);
 
     if (!ok) {
         SPDLOG_ERROR("[OPENMP] Failed to register {} attribute handler", OUTER_ATTR_NAME);

--- a/lib/attributes/backend/openmp/restrict.cpp
+++ b/lib/attributes/backend/openmp/restrict.cpp
@@ -7,7 +7,7 @@ using namespace oklt;
 using namespace clang;
 
 __attribute__((constructor)) void registerOPENMPRestrictHandler() {
-    auto ok = HandlerManager::registerBackendHandler(
+    auto ok = registerBackendHandler(
         TargetBackend::OPENMP, RESTRICT_ATTR_NAME, serial_subset::handleRestrictAttribute);
 
     if (!ok) {

--- a/lib/attributes/backend/openmp/shared.cpp
+++ b/lib/attributes/backend/openmp/shared.cpp
@@ -8,11 +8,11 @@ using namespace oklt;
 using namespace clang;
 
 __attribute__((constructor)) void registerOPENMPSharedHandler() {
-    auto ok = HandlerManager::registerBackendHandler(
+    auto ok = registerBackendHandler(
         TargetBackend::OPENMP, SHARED_ATTR_NAME, serial_subset::handleSharedAttribute);
 
     // Empty Stmt handler since @shared variable is of attributed type, it is called on DeclRefExpr
-    ok &= HandlerManager::registerBackendHandler(
+    ok &= registerBackendHandler(
         TargetBackend::OPENMP, SHARED_ATTR_NAME, defaultHandleSharedStmtAttribute);
 
     if (!ok) {

--- a/lib/attributes/backend/openmp/tile.cpp
+++ b/lib/attributes/backend/openmp/tile.cpp
@@ -28,8 +28,8 @@ HandleResult handleOPENMPTileAttribute(SessionStage& s,
 }
 
 __attribute__((constructor)) void registerOPENMPSharedHandler() {
-    auto ok = HandlerManager::registerBackendHandler(
-        TargetBackend::OPENMP, TILE_ATTR_NAME, handleOPENMPTileAttribute);
+    auto ok =
+        registerBackendHandler(TargetBackend::OPENMP, TILE_ATTR_NAME, handleOPENMPTileAttribute);
 
     if (!ok) {
         SPDLOG_ERROR("[OPENMP] Failed to register {} attribute handler", TILE_ATTR_NAME);

--- a/lib/attributes/backend/serial/atomic.cpp
+++ b/lib/attributes/backend/serial/atomic.cpp
@@ -7,7 +7,7 @@ using namespace oklt;
 using namespace clang;
 
 __attribute__((constructor)) void registerOPENMPAtomicHandler() {
-    auto ok = HandlerManager::registerBackendHandler(
+    auto ok = registerBackendHandler(
         TargetBackend::SERIAL, ATOMIC_ATTR_NAME, serial_subset::handleEmptyStmtAttribute);
 
     if (!ok) {

--- a/lib/attributes/backend/serial/barrier.cpp
+++ b/lib/attributes/backend/serial/barrier.cpp
@@ -7,7 +7,7 @@ using namespace oklt;
 using namespace clang;
 
 __attribute__((constructor)) void registerOPENMPBarrierHandler() {
-    auto ok = HandlerManager::registerBackendHandler(
+    auto ok = registerBackendHandler(
         TargetBackend::SERIAL, BARRIER_ATTR_NAME, serial_subset::handleEmptyStmtAttribute);
 
     if (!ok) {

--- a/lib/attributes/backend/serial/exclusive.cpp
+++ b/lib/attributes/backend/serial/exclusive.cpp
@@ -7,9 +7,9 @@ using namespace oklt;
 using namespace clang;
 
 __attribute__((constructor)) void registerOPENMPExclusiveHandler() {
-    auto ok = HandlerManager::registerBackendHandler(
+    auto ok = registerBackendHandler(
         TargetBackend::SERIAL, EXCLUSIVE_ATTR_NAME, serial_subset::handleExclusiveExprAttribute);
-    ok &= HandlerManager::registerBackendHandler(
+    ok &= registerBackendHandler(
         TargetBackend::SERIAL, EXCLUSIVE_ATTR_NAME, serial_subset::handleExclusiveDeclAttribute);
 
     if (!ok) {

--- a/lib/attributes/backend/serial/inner.cpp
+++ b/lib/attributes/backend/serial/inner.cpp
@@ -7,7 +7,7 @@ using namespace oklt;
 using namespace clang;
 
 __attribute__((constructor)) void registerOPENMPOuterHandler() {
-    auto ok = HandlerManager::registerBackendHandler(
+    auto ok = registerBackendHandler(
         TargetBackend::SERIAL, INNER_ATTR_NAME, serial_subset::handleInnerAttribute);
 
     if (!ok) {

--- a/lib/attributes/backend/serial/kernel.cpp
+++ b/lib/attributes/backend/serial/kernel.cpp
@@ -7,7 +7,7 @@ using namespace oklt;
 using namespace clang;
 
 __attribute__((constructor)) void registerOPENMPKernelHandler() {
-    auto ok = HandlerManager::registerBackendHandler(
+    auto ok = registerBackendHandler(
         TargetBackend::SERIAL, KERNEL_ATTR_NAME, serial_subset::handleKernelAttribute);
 
     if (!ok) {

--- a/lib/attributes/backend/serial/outer.cpp
+++ b/lib/attributes/backend/serial/outer.cpp
@@ -7,7 +7,7 @@ using namespace oklt;
 using namespace clang;
 
 __attribute__((constructor)) void registerOPENMPOuterHandler() {
-    auto ok = HandlerManager::registerBackendHandler(
+    auto ok = registerBackendHandler(
         TargetBackend::SERIAL, OUTER_ATTR_NAME, serial_subset::handleOuterAttribute);
 
     if (!ok) {

--- a/lib/attributes/backend/serial/restrict.cpp
+++ b/lib/attributes/backend/serial/restrict.cpp
@@ -7,7 +7,7 @@ using namespace oklt;
 using namespace clang;
 
 __attribute__((constructor)) void registerOPENMPRestrictHandler() {
-    auto ok = HandlerManager::registerBackendHandler(
+    auto ok = registerBackendHandler(
         TargetBackend::SERIAL, RESTRICT_ATTR_NAME, serial_subset::handleRestrictAttribute);
 
     if (!ok) {

--- a/lib/attributes/backend/serial/shared.cpp
+++ b/lib/attributes/backend/serial/shared.cpp
@@ -8,11 +8,11 @@ using namespace oklt;
 using namespace clang;
 
 __attribute__((constructor)) void registerOPENMPSharedHandler() {
-    auto ok = HandlerManager::registerBackendHandler(
+    auto ok = registerBackendHandler(
         TargetBackend::SERIAL, SHARED_ATTR_NAME, serial_subset::handleSharedAttribute);
 
     // Empty Stmt handler since @shared variable is of attributed type, it is called on DeclRefExpr
-    ok &= HandlerManager::registerBackendHandler(
+    ok &= registerBackendHandler(
         TargetBackend::SERIAL, SHARED_ATTR_NAME, defaultHandleSharedStmtAttribute);
 
     if (!ok) {

--- a/lib/attributes/backend/serial/tile.cpp
+++ b/lib/attributes/backend/serial/tile.cpp
@@ -7,7 +7,7 @@ using namespace oklt;
 using namespace clang;
 
 __attribute__((constructor)) void registerOPENMPSharedHandler() {
-    auto ok = HandlerManager::registerBackendHandler(
+    auto ok = registerBackendHandler(
         TargetBackend::SERIAL, TILE_ATTR_NAME, serial_subset::handleTileAttribute);
 
     if (!ok) {

--- a/lib/attributes/frontend/atomic.cpp
+++ b/lib/attributes/frontend/atomic.cpp
@@ -54,7 +54,7 @@ HandleResult parseAtomicAttrParams(SessionStage& stage, const Attr& attr, OKLPar
     return EmptyParams{};
 }
 
-__attribute__((constructor)) void registerAttrFrontend() {
-    HandlerManager::registerAttrFrontend<AtomicAttribute>(ATOMIC_ATTR_NAME, parseAtomicAttrParams);
+__attribute__((constructor)) void registerAtomicAttrFrontend() {
+    registerAttrFrontend<AtomicAttribute>(ATOMIC_ATTR_NAME, parseAtomicAttrParams);
 }
 }  // namespace

--- a/lib/attributes/frontend/barrier.cpp
+++ b/lib/attributes/frontend/barrier.cpp
@@ -81,8 +81,7 @@ HandleResult parseBarrierAttrParams(SessionStage& stage,
     return ret;
 }
 
-__attribute__((constructor)) void registerAttrFrontend() {
-    HandlerManager::registerAttrFrontend<BarrierAttribute>(BARRIER_ATTR_NAME,
-                                                           parseBarrierAttrParams);
+__attribute__((constructor)) void registerBarrierAttrFrontend() {
+    registerAttrFrontend<BarrierAttribute>(BARRIER_ATTR_NAME, parseBarrierAttrParams);
 }
 }  // namespace

--- a/lib/attributes/frontend/dim.cpp
+++ b/lib/attributes/frontend/dim.cpp
@@ -151,8 +151,8 @@ HandleResult parseDimAttrParams(SessionStage& stage, const clang::Attr& attr, OK
     return ret;
 }
 
-__attribute__((constructor)) void registerAttrFrontend() {
-    HandlerManager::registerAttrFrontend<DimAttribute>(DIM_ATTR_NAME, parseDimAttrParams);
+__attribute__((constructor)) void registerDimAttrFrontend() {
+    registerAttrFrontend<DimAttribute>(DIM_ATTR_NAME, parseDimAttrParams);
     // for suppression of func call error that potentially is dim calls
     static DiagHandlerRegistry::Add<DimDiagHandler> diag_dim("DimDiagHandler", "");
 }

--- a/lib/attributes/frontend/dim_order.cpp
+++ b/lib/attributes/frontend/dim_order.cpp
@@ -142,8 +142,7 @@ HandleResult parseDimOrderAttrParams(SessionStage& stage,
     return ret;
 }
 
-__attribute__((constructor)) void registerAttrFrontend() {
-    HandlerManager::registerAttrFrontend<DimOrderAttribute>(DIM_ORDER_ATTR_NAME,
-                                                            parseDimOrderAttrParams);
+__attribute__((constructor)) void registerDimOrderAttrFrontend() {
+    registerAttrFrontend<DimOrderAttribute>(DIM_ORDER_ATTR_NAME, parseDimOrderAttrParams);
 }
 }  // namespace

--- a/lib/attributes/frontend/exclusive.cpp
+++ b/lib/attributes/frontend/exclusive.cpp
@@ -114,7 +114,6 @@ HandleResult parseExclusiveAttrParams(SessionStage& stage,
 }
 
 __attribute__((constructor)) void registerKernelHandler() {
-    HandlerManager::registerAttrFrontend<ExclusiveAttribute>(EXCLUSIVE_ATTR_NAME,
-                                                             parseExclusiveAttrParams);
+    registerAttrFrontend<ExclusiveAttribute>(EXCLUSIVE_ATTR_NAME, parseExclusiveAttrParams);
 }
 }  // namespace

--- a/lib/attributes/frontend/inner.cpp
+++ b/lib/attributes/frontend/inner.cpp
@@ -74,7 +74,7 @@ HandleResult parseInnerAttrParams(SessionStage& stage,
     return ret;
 }
 
-__attribute__((constructor)) void registerAttrFrontend() {
-    HandlerManager::registerAttrFrontend<InnerAttribute>(INNER_ATTR_NAME, parseInnerAttrParams);
+__attribute__((constructor)) void registerInnerAttrFrontend() {
+    registerAttrFrontend<InnerAttribute>(INNER_ATTR_NAME, parseInnerAttrParams);
 }
 }  // namespace

--- a/lib/attributes/frontend/kernel.cpp
+++ b/lib/attributes/frontend/kernel.cpp
@@ -59,7 +59,7 @@ HandleResult parseKernelAttrParams(SessionStage& stage,
     return EmptyParams{};
 }
 
-__attribute__((constructor)) void registerAttrFrontend() {
-    HandlerManager::registerAttrFrontend<KernelAttribute>(KERNEL_ATTR_NAME, parseKernelAttrParams);
+__attribute__((constructor)) void registerKernelAttrFrontend() {
+    registerAttrFrontend<KernelAttribute>(KERNEL_ATTR_NAME, parseKernelAttrParams);
 }
 }  // namespace

--- a/lib/attributes/frontend/max_inner_dims.cpp
+++ b/lib/attributes/frontend/max_inner_dims.cpp
@@ -72,7 +72,7 @@ HandleResult parseMaxInnerDims(SessionStage& stage, const clang::Attr& attr, OKL
     return ret;
 }
 
-__attribute__((constructor)) void registerAttrFrontend() {
-    HandlerManager::registerAttrFrontend<MaxInnerDims>(MAX_INNER_DIMS, parseMaxInnerDims);
+__attribute__((constructor)) void registerMaxInnerDimsAttrFrontend() {
+    registerAttrFrontend<MaxInnerDims>(MAX_INNER_DIMS, parseMaxInnerDims);
 }
 }  // namespace

--- a/lib/attributes/frontend/no_barrier.cpp
+++ b/lib/attributes/frontend/no_barrier.cpp
@@ -60,8 +60,7 @@ HandleResult parseNoBarrierAttrParams(SessionStage& stage,
     return EmptyParams{};
 }
 
-__attribute__((constructor)) void registerAttrFrontend() {
-    HandlerManager::registerAttrFrontend<NoBarrierAttribute>(NO_BARRIER_ATTR_NAME,
-                                                             parseNoBarrierAttrParams);
+__attribute__((constructor)) void registerNoBarrierAttrFrontend() {
+    registerAttrFrontend<NoBarrierAttribute>(NO_BARRIER_ATTR_NAME, parseNoBarrierAttrParams);
 }
 }  // namespace

--- a/lib/attributes/frontend/outer.cpp
+++ b/lib/attributes/frontend/outer.cpp
@@ -73,7 +73,7 @@ HandleResult parseOuterAttrParams(SessionStage& stage,
     return ret;
 }
 
-__attribute__((constructor)) void registerAttrFrontend() {
-    HandlerManager::registerAttrFrontend<OuterAttribute>(OUTER_ATTR_NAME, parseOuterAttrParams);
+__attribute__((constructor)) void registerOuterAttrFrontend() {
+    registerAttrFrontend<OuterAttribute>(OUTER_ATTR_NAME, parseOuterAttrParams);
 }
 }  // namespace

--- a/lib/attributes/frontend/restrict.cpp
+++ b/lib/attributes/frontend/restrict.cpp
@@ -68,8 +68,7 @@ HandleResult parseRestrictAttrParams(SessionStage& stage,
     return EmptyParams{};
 }
 
-__attribute__((constructor)) void registerAttrFrontend() {
-    HandlerManager::registerAttrFrontend<RestrictAttribute>(RESTRICT_ATTR_NAME,
-                                                            parseRestrictAttrParams);
+__attribute__((constructor)) void registerRestrictAttrFrontend() {
+    registerAttrFrontend<RestrictAttribute>(RESTRICT_ATTR_NAME, parseRestrictAttrParams);
 }
 }  // namespace

--- a/lib/attributes/frontend/shared.cpp
+++ b/lib/attributes/frontend/shared.cpp
@@ -122,7 +122,7 @@ HandleResult parseSharedAttrParams(SessionStage& stage,
     return EmptyParams{};
 }
 
-__attribute__((constructor)) void registerAttrFrontend() {
-    HandlerManager::registerAttrFrontend<SharedAttribute>(SHARED_ATTR_NAME, parseSharedAttrParams);
+__attribute__((constructor)) void registerSharedAttrFrontend() {
+    registerAttrFrontend<SharedAttribute>(SHARED_ATTR_NAME, parseSharedAttrParams);
 }
 }  // namespace

--- a/lib/attributes/frontend/tile.cpp
+++ b/lib/attributes/frontend/tile.cpp
@@ -105,8 +105,8 @@ HandleResult parseTileAttribute(SessionStage& stage, const clang::Attr& attr, OK
     return ret;
 }
 
-__attribute__((constructor)) void registerAttrFrontend() {
-    HandlerManager::registerAttrFrontend<TileAttribute>(TILE_ATTR_NAME, parseTileAttribute);
+__attribute__((constructor)) void registerTileAttrFrontend() {
+    registerAttrFrontend<TileAttribute>(TILE_ATTR_NAME, parseTileAttribute);
 }
 
 }  // namespace

--- a/lib/core/handler_manager/attr_handler.h
+++ b/lib/core/handler_manager/attr_handler.h
@@ -113,8 +113,8 @@ struct HandlerKey<H, std::enable_if_t<H == HandleType::COMMON>> : public HandleK
 };
 
 template <typename F>
-inline bool HandlerManager::registerCommonHandler(std::string attr, F& func) {
-    return _map().insert(HandlerKey<HandleType::COMMON>(attr), func);
+inline bool registerCommonHandler(std::string attr, F& func) {
+    return HandlerManager::_map().insert(HandlerKey<HandleType::COMMON>(attr), func);
 };
 
 }  // namespace oklt

--- a/lib/core/handler_manager/backend_handler.h
+++ b/lib/core/handler_manager/backend_handler.h
@@ -31,10 +31,9 @@ struct HandlerKey<T, std::enable_if_t<T == HandleType::BACKEND>> : public Handle
 };
 
 template <typename F>
-inline bool HandlerManager::registerBackendHandler(TargetBackend backend,
-                                                   std::string attr,
+inline bool registerBackendHandler(TargetBackend backend, std::string attr,
                                                    F& func) {
-    return _map().insert(HandlerKey<HandleType::BACKEND>(backend, attr), func);
+    return HandlerManager::_map().insert(HandlerKey<HandleType::BACKEND>(backend, attr), func);
 };
 
 }  // namespace oklt

--- a/lib/core/handler_manager/handler_manager.h
+++ b/lib/core/handler_manager/handler_manager.h
@@ -23,15 +23,15 @@ class HandlerManager {
     ~HandlerManager() = default;
 
     template <typename AttrFrontendType, typename F>
-    static bool registerAttrFrontend(std::string attr, F& func);
+    friend bool registerAttrFrontend(std::string attr, F& func);
     template <typename F>
-    static bool registerCommonHandler(std::string attr, F& func);
+    friend bool registerCommonHandler(std::string attr, F& func);
     template <typename F>
-    static bool registerBackendHandler(TargetBackend, std::string attr, F& func);
+    friend bool registerBackendHandler(TargetBackend, std::string attr, F& func);
     template <typename F>
-    static bool registerImplicitHandler(TargetBackend, F& func);
+    friend bool registerImplicitHandler(TargetBackend, F& func);
     template <typename F>
-    static bool registerSemaHandler(std::string attr, F& pre, F& post);
+    friend bool registerSemaHandler(std::string attr, F& pre, F& post);
 
     [[nodiscard]] bool hasImplicitHandler(TargetBackend backend, clang::ASTNodeKind kind);
     [[nodiscard]] HandleResult parseAttr(SessionStage& stage, const clang::Attr& attr);

--- a/lib/core/handler_manager/implicid_handler.h
+++ b/lib/core/handler_manager/implicid_handler.h
@@ -86,8 +86,8 @@ struct HandlerKey<T, std::enable_if_t<T == HandleType::IMPLICIT>> : public Handl
 };
 
 template <typename F>
-inline bool HandlerManager::registerImplicitHandler(TargetBackend backend, F& func) {
-    return _map().insert(HandlerKey<HandleType::IMPLICIT>(backend), func);
+inline bool registerImplicitHandler(TargetBackend backend, F& func) {
+    return HandlerManager::_map().insert(HandlerKey<HandleType::IMPLICIT>(backend), func);
 }
 
 }  // namespace oklt

--- a/lib/core/handler_manager/parse_handler.h
+++ b/lib/core/handler_manager/parse_handler.h
@@ -53,9 +53,9 @@ struct HandlerKey<T, std::enable_if_t<T == HandleType::PARSER>> : public HandleK
 };
 
 template <typename AttrFrontendType, typename F>
-inline bool HandlerManager::registerAttrFrontend(std::string attr, F& func) {
+inline bool registerAttrFrontend(std::string attr, F& func) {
     static clang::ParsedAttrInfoRegistry::Add<AttrFrontendType> register_okl_atomic(attr, "");
-    return _map().insert(HandlerKey<HandleType::PARSER>(attr), func);
+    return HandlerManager::_map().insert(HandlerKey<HandleType::PARSER>(attr), func);
 };
 
 }  // namespace oklt

--- a/lib/core/handler_manager/sema_handler.h
+++ b/lib/core/handler_manager/sema_handler.h
@@ -109,8 +109,8 @@ struct HandlerKey<H, std::enable_if_t<H == HandleType::SEMA>> : public HandleKey
 };
 
 template <typename F>
-inline bool HandlerManager::registerSemaHandler(std::string attr, F& pre, F& post) {
-    return _map().insert(HandlerKey<HandleType::SEMA>(attr), pre, post);
+inline bool registerSemaHandler(std::string attr, F& pre, F& post) {
+    return HandlerManager::_map().insert(HandlerKey<HandleType::SEMA>(attr), pre, post);
 }
 
 }  // namespace oklt

--- a/lib/core/sema/processor.cpp
+++ b/lib/core/sema/processor.cpp
@@ -12,26 +12,22 @@ using namespace oklt;
 
 __attribute__((constructor)) void registerOklSemaProcessor() {
     // sema handler for OKL kernel attribute
-    auto ok = HandlerManager::registerSemaHandler(
-        KERNEL_ATTR_NAME, preValidateOklKernel, postValidateOklKernel);
+    auto ok = registerSemaHandler(KERNEL_ATTR_NAME, preValidateOklKernel, postValidateOklKernel);
     assert(ok);
 
     // sema handler for OKL tile attribute
-    ok = HandlerManager::registerSemaHandler(
-        TILE_ATTR_NAME, preValidateOklForLoop, postValidateOklForLoop);
+    ok = registerSemaHandler(TILE_ATTR_NAME, preValidateOklForLoop, postValidateOklForLoop);
     assert(ok);
 
     // sema handler for OKL outer attribute
-    ok = HandlerManager::registerSemaHandler(
-        OUTER_ATTR_NAME, preValidateOklForLoop, postValidateOklForLoop);
+    ok = registerSemaHandler(OUTER_ATTR_NAME, preValidateOklForLoop, postValidateOklForLoop);
     assert(ok);
 
     // sema handler for OKL inner attribute
-    ok = HandlerManager::registerSemaHandler(
-        INNER_ATTR_NAME, preValidateOklForLoop, postValidateOklForLoop);
+    ok = registerSemaHandler(INNER_ATTR_NAME, preValidateOklForLoop, postValidateOklForLoop);
     assert(ok);
 
-    ok = HandlerManager::registerSemaHandler(
+    ok = registerSemaHandler(
         "", preValidateOklForLoopWithoutAttribute, postValidateOklForLoopWithoutAttribute);
 
     assert(ok);


### PR DESCRIPTION
`HandlerManager` got full of `register` cheating, and got a divorce.
Now all `register` methods are firendzoned and learned their lesson to no longer cause linkage problems.