### PR TITLE
Fix inner loops size calculation in casae of @tile(@inner), and @tile(@inner, @inner)

### DIFF
--- a/lib/core/sema/okl_sema_info.cpp
+++ b/lib/core/sema/okl_sema_info.cpp
@@ -181,29 +181,13 @@ OklLoopInfo::OptSizes OklLoopInfo::getInnerSizes() {
     if (overridenInnerSizes.has_value()) {
         return overridenInnerSizes.value();
     }
+    OklLoopInfo::OptSizes ret{1, 1, 1};
+
     if (isRegular()) {
         if (children.empty()) {
-            return {1, 1, 1};
+            return ret;
         }
     }
-
-    OptSize sz = std::nullopt;
-    if (is(LoopType::Inner) && range.size != 0) {
-        sz = range.size;
-    } else if (is(LoopType::Outer, LoopType::Inner)) {
-        if (!tileSize.empty()) {
-            // TODO: maybe reuse attribute parser
-            char* p;
-            auto tileSizeLL = std::strtoll(tileSize.c_str(), &p, 10);
-            if (*p) {
-                sz = std::nullopt;
-            } else {
-                sz = static_cast<size_t>(tileSizeLL);
-            }
-        }
-    }
-
-    OklLoopInfo::OptSizes ret{1, 1, 1};
 
 #ifdef LEGACY_INNER_SIZES_CALCULATION
     if (!children.empty()) {
@@ -222,9 +206,26 @@ OklLoopInfo::OptSizes OklLoopInfo::getInnerSizes() {
 #endif
 
     if (has(LoopType::Inner)) {
-        for (size_t i = 0; i < type.size(); ++i) {
-            if (type[i] == LoopType::Inner) {
-                ret[static_cast<size_t>(axis[i])] = sz;
+        if (type.size() == 1) {
+            ret[static_cast<size_t>(axis[0])] =
+                range.size == 0 ? std::nullopt : std::make_optional(range.size);
+        } else if (type.size() == 2) {  // Tiled loop
+            // TODO: maybe reuse attribute parser
+            char* p;
+            auto tileSizeLL = std::strtoll(tileSize.c_str(), &p, 10);
+
+            // if tile size is known at compile time, then it is a size of the second loop
+            if (type[1] == LoopType::Inner) {
+                ret[static_cast<size_t>(axis[1])] =
+                    *p ? std::nullopt : std::make_optional(static_cast<size_t>(tileSizeLL));
+            }
+            // if both tile size and range size are known at compile time, then ceil(range size /
+            // tile size) is a size of loop
+            if (type[0] == LoopType::Inner) {
+                ret[static_cast<size_t>(axis[0])] = *p || range.size == 0
+                                                        ? std::nullopt
+                                                        : std::make_optional(static_cast<size_t>(
+                                                              1 + ((range.size - 1) / tileSizeLL)));
             }
         }
     }

--- a/lib/core/sema/okl_sema_info.cpp
+++ b/lib/core/sema/okl_sema_info.cpp
@@ -183,10 +183,8 @@ OklLoopInfo::OptSizes OklLoopInfo::getInnerSizes() {
     }
     OklLoopInfo::OptSizes ret{1, 1, 1};
 
-    if (isRegular()) {
-        if (children.empty()) {
-            return ret;
-        }
+    if (isRegular() && children.empty()) {
+        return ret;
     }
 
 #ifdef LEGACY_INNER_SIZES_CALCULATION

--- a/tests/functional/data/transpiler/backends/cuda/shared/shared_between_tiles_ref.cpp
+++ b/tests/functional/data/transpiler/backends/cuda/shared/shared_between_tiles_ref.cpp
@@ -1,6 +1,6 @@
 #include <cuda_runtime.h>
 
-extern "C" __global__ void _occa_test_kern_0() {
+extern "C" __global__ __launch_bounds__(12) void _occa_test_kern_0() {
   {
     int _occa_tiled_i = (0) + ((4) * blockIdx.x);
     for (int i = _occa_tiled_i; i < (_occa_tiled_i + (4)); ++i) {

--- a/tests/functional/data/transpiler/backends/dpcpp/shared/shared_between_tiles_ref.cpp
+++ b/tests/functional/data/transpiler/backends/dpcpp/shared/shared_between_tiles_ref.cpp
@@ -1,7 +1,7 @@
 #include <CL/sycl.hpp>
 using namespace sycl;
 
-extern "C" void _occa_test_kern_0(sycl::queue *queue_,
+extern "C" [[sycl::reqd_work_group_size(1, 3, 4)]] void _occa_test_kern_0(sycl::queue *queue_,
                                   sycl::nd_range<3> *range_) {
   queue_->submit([&](sycl::handler &handler_) {
     handler_.parallel_for(*range_, [=](sycl::nd_item<3> item_) {

--- a/tests/functional/data/transpiler/backends/hip/shared/shared_between_tiles_ref.cpp
+++ b/tests/functional/data/transpiler/backends/hip/shared/shared_between_tiles_ref.cpp
@@ -1,6 +1,6 @@
 #include <hip/hip_runtime.h>
 
-extern "C" __global__ void _occa_test_kern_0() {
+extern "C" __global__ __launch_bounds__(12) void _occa_test_kern_0() {
   {
     int _occa_tiled_i = (0) + ((4) * blockIdx.x);
     for (int i = _occa_tiled_i; i < (_occa_tiled_i + (4)); ++i) {


### PR DESCRIPTION
Fix launch bound calculation for @tile(@inner), and @tile(@inner, @inner) 
Should fix https://github.com/libocca/occa-transpiler/issues/200 