### PR TITLE
use internal variable to provide the path for submodule dependencies

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -234,16 +234,16 @@ set (OCCA_TRANSPILER_SOURCES
 )
 
 CPMAddPackage(NAME expected
-    SOURCE_DIR ${CMAKE_SOURCE_DIR}/deps/expected
+    SOURCE_DIR ${ROOT_DIR}/deps/expected
     OPTIONS "EXPECTED_BUILD_TESTS OFF" "EXPECTED_BUILD_PACKAGE OFF"
 )
 
 CPMAddPackage(NAME nlohmann_json
-    SOURCE_DIR ${CMAKE_SOURCE_DIR}/deps/json
+    SOURCE_DIR ${ROOT_DIR}/deps/json
     OPTIONS "JSON_BuildTests OFF")
 
 CPMAddPackage(NAME spdlog
-  SOURCE_DIR ${CMAKE_SOURCE_DIR}/deps/spdlog
+  SOURCE_DIR ${ROOT_DIR}/deps/spdlog
   OPTIONS "SPDLOG_BUILD_EXAMPLE OFF" "SPDLOG_NO_EXCEPTIONS ON")
 
 set(LLVM_LINK_COMPONENTS Support)

--- a/tests/functional/CMakeLists.txt
+++ b/tests/functional/CMakeLists.txt
@@ -7,12 +7,12 @@ CPMAddPackage(
 
 CPMAddPackage(
   NAME argparser
-  SOURCE_DIR ${CMAKE_SOURCE_DIR}/deps/argparse
+  SOURCE_DIR ${ROOT_DIR}/deps/argparse
   OPTIONS "ARGPARSE_BUILD_TESTS OFF"
 )
 
 CPMAddPackage(NAME nlohmann_json
-   SOURCE_DIR ${CMAKE_SOURCE_DIR}/deps/json
+   SOURCE_DIR ${ROOT_DIR}/deps/json
    OPTIONS "JSON_BuildTests OFF")
 
 CPMAddPackage(NAME spdlog

--- a/tool/CMakeLists.txt
+++ b/tool/CMakeLists.txt
@@ -3,12 +3,12 @@ project (occa-tool VERSION 0.0.1 LANGUAGES CXX)
 
 CPMAddPackage(
   NAME argparser
-  SOURCE_DIR ${CMAKE_SOURCE_DIR}/deps/argparse
+  SOURCE_DIR ${ROOT_DIR}/deps/argparse
   OPTIONS "ARGPARSE_BUILD_TESTS OFF"
 )
 
 CPMAddPackage(NAME spdlog
-  SOURCE_DIR ${CMAKE_SOURCE_DIR}/deps/spdlog
+  SOURCE_DIR ${ROOT_DIR}/deps/spdlog
   OPTIONS "SPDLOG_BUILD_EXAMPLE OFF" "SPDLOG_NO_EXCEPTIONS ON")
 
 


### PR DESCRIPTION
For the occa integration with submodule the occa-transpiler submodule paths should be relative to the project