### PR TITLE
Fix loops structure check fails when regular at the same level as attributed

### DIFF
--- a/lib/attributes/utils/kernel_utils.cpp
+++ b/lib/attributes/utils/kernel_utils.cpp
@@ -40,6 +40,17 @@ int32_t getNextAttributedTypeIdx(const LoopTypes& loopTypes, int32_t currIdx) {
     return -1;
 }
 
+void addLoopChildrenToQueue(std::deque<LoopTreeNode>& queue, OklLoopInfo& loop) {
+    for (auto& child : loop.children) {
+        if (!child.isRegular()) {
+            queue.push_back({&child});
+        } else {
+            // Add all children of regular loop
+            addLoopChildrenToQueue(queue, child);
+        }
+    }
+}
+
 /**
  * @brief Function to verify the loop structure recursively using Breadth-First Search (BFS).
  * @param queue A queue of loop tree nodes to verify.
@@ -101,9 +112,7 @@ tl::expected<void, std::pair<const clang::ForStmt*, std::string>> verifyLoopStru
                 node.typeIdx = nextTiledTypeIdx;
                 nextQueue.push_back(node);
             } else if (currHasChildren) {
-                for (auto& child : node.loop->children) {
-                    nextQueue.push_back(LoopTreeNode{&child});
-                }
+                addLoopChildrenToQueue(nextQueue, *node.loop);
             } else {
                 // Missing child loop case
                 return tl::make_unexpected(

--- a/lib/attributes/utils/kernel_utils.cpp
+++ b/lib/attributes/utils/kernel_utils.cpp
@@ -40,6 +40,13 @@ int32_t getNextAttributedTypeIdx(const LoopTypes& loopTypes, int32_t currIdx) {
     return -1;
 }
 
+/**
+ * @brief Function to add all children of a loop having at least one attributed children to the
+ * queue.
+ *
+ * @param queue next queue of BFS traversal
+ * @param loop loop to add children of
+ */
 void addLoopChildrenToQueue(std::deque<LoopTreeNode>& queue, OklLoopInfo& loop) {
     for (auto& child : loop.children) {
         if (!child.isRegular()) {

--- a/tests/functional/configs/test_suite_transpiler/backends/cuda/inner_outer.json
+++ b/tests/functional/configs/test_suite_transpiler/backends/cuda/inner_outer.json
@@ -42,5 +42,16 @@
       "launcher": ""
     },
     "reference": "transpiler/backends/cuda/outer_inner/outer_inner_split_ref.cpp"
+  },
+  {
+    "action": "normalize_and_transpile",
+    "action_config": {
+      "backend": "cuda",
+      "source": "transpiler/backends/cuda/outer_inner/outer_inner_regular_at_same_level_as_attributed.cpp",
+      "includes": [],
+      "defs": [],
+      "launcher": ""
+    },
+    "reference": "transpiler/backends/cuda/outer_inner/outer_inner_regular_at_same_level_as_attributed_ref.cpp"
   }
 ]

--- a/tests/functional/configs/test_suite_transpiler/backends/dpcpp/inner_outer.json
+++ b/tests/functional/configs/test_suite_transpiler/backends/dpcpp/inner_outer.json
@@ -42,5 +42,16 @@
             "launcher": ""
         },
         "reference": "transpiler/backends/dpcpp/outer_inner/outer_inner_split_ref.cpp"
+    },
+    {
+      "action": "normalize_and_transpile",
+      "action_config": {
+        "backend": "dpcpp",
+        "source": "transpiler/backends/dpcpp/outer_inner/outer_inner_regular_at_same_level_as_attributed.cpp",
+        "includes": [],
+        "defs": [],
+        "launcher": ""
+      },
+      "reference": "transpiler/backends/dpcpp/outer_inner/outer_inner_regular_at_same_level_as_attributed_ref.cpp"
     }
 ]

--- a/tests/functional/configs/test_suite_transpiler/backends/hip/inner_outer.json
+++ b/tests/functional/configs/test_suite_transpiler/backends/hip/inner_outer.json
@@ -42,5 +42,16 @@
             "launcher": ""
         },
         "reference": "transpiler/backends/hip/outer_inner/outer_inner_split_ref.cpp"
+    },
+    {
+      "action": "normalize_and_transpile",
+      "action_config": {
+        "backend": "hip",
+        "source": "transpiler/backends/hip/outer_inner/outer_inner_regular_at_same_level_as_attributed.cpp",
+        "includes": [],
+        "defs": [],
+        "launcher": ""
+      },
+      "reference": "transpiler/backends/hip/outer_inner/outer_inner_regular_at_same_level_as_attributed_ref.cpp"
     }
 ]

--- a/tests/functional/configs/test_suite_transpiler/backends/launcher/inner_outer.json
+++ b/tests/functional/configs/test_suite_transpiler/backends/launcher/inner_outer.json
@@ -42,5 +42,16 @@
       "launcher": ""
     },
     "reference": "transpiler/backends/launcher/outer_inner/outer_inner_split_ref.cpp"
+  },
+  {
+    "action": "normalize_and_transpile",
+    "action_config": {
+      "backend": "launcher",
+      "source": "transpiler/backends/launcher/outer_inner/outer_inner_regular_at_same_level_as_attributed.cpp",
+      "includes": [],
+      "defs": [],
+      "launcher": ""
+    },
+    "reference": "transpiler/backends/launcher/outer_inner/outer_inner_regular_at_same_level_as_attributed_ref.cpp"
   }
 ]

--- a/tests/functional/configs/test_suite_transpiler/backends/openmp/inner_outer.json
+++ b/tests/functional/configs/test_suite_transpiler/backends/openmp/inner_outer.json
@@ -31,5 +31,16 @@
       "launcher": ""
     },
     "reference": "transpiler/backends/openmp/outer_inner/bug_141_ref.cpp"
+  },
+  {
+    "action": "normalize_and_transpile",
+    "action_config": {
+      "backend": "openmp",
+      "source": "transpiler/backends/openmp/outer_inner/outer_inner_regular_at_same_level_as_attributed.cpp",
+      "includes": [],
+      "defs": [],
+      "launcher": ""
+    },
+    "reference": "transpiler/backends/openmp/outer_inner/outer_inner_regular_at_same_level_as_attributed_ref.cpp"
   }
 ]

--- a/tests/functional/configs/test_suite_transpiler/backends/serial/inner_outer.json
+++ b/tests/functional/configs/test_suite_transpiler/backends/serial/inner_outer.json
@@ -20,5 +20,16 @@
       "launcher": ""
     },
     "reference": "transpiler/backends/serial/outer_inner/outer_inner_dec_ref.cpp"
+  },
+  {
+    "action": "normalize_and_transpile",
+    "action_config": {
+      "backend": "serial",
+      "source": "transpiler/backends/serial/outer_inner/outer_inner_regular_at_same_level_as_attributed.cpp",
+      "includes": [],
+      "defs": [],
+      "launcher": ""
+    },
+    "reference": "transpiler/backends/serial/outer_inner/outer_inner_regular_at_same_level_as_attributed_ref.cpp"
   }
 ]

--- a/tests/functional/data/transpiler/backends/cuda/outer_inner/outer_inner_regular_at_same_level_as_attributed.cpp
+++ b/tests/functional/data/transpiler/backends/cuda/outer_inner/outer_inner_regular_at_same_level_as_attributed.cpp
@@ -1,0 +1,32 @@
+@kernel void test_kernel() {
+    @outer for (int i = 0; i < 10; ++i) {
+        @outer for (int i2 = 0; i2 < 10; ++i2) {
+            @inner for (int j = 0; j < 10; ++j) {
+            }
+
+            for (int ii = 0; ii < 10; ++ii) {
+                @inner for (int j = 0; j < 10; ++j) {
+                }
+                for (int j = 0; j < 10; ++j) {
+                }
+            }
+        }
+
+        for (int ii = 0; ii < 10; ++ii) {
+            @outer for (int i = 0; i < 10; ++i) {
+                @inner for (int j = 0; j < 10; ++j) {
+                }
+            }
+        }
+    }
+    for (int ii = 0; ii < 10; ++ii) {
+        @outer for (int i = 0; i < 10; ++i) {
+            for (int i2 = 0; i2 < 10; ++i2) {
+                @outer for (int i2 = 0; i2 < 10; ++i2) {
+                    @inner for (int j = 0; j < 10; ++j) {
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/functional/data/transpiler/backends/cuda/outer_inner/outer_inner_regular_at_same_level_as_attributed_ref.cpp
+++ b/tests/functional/data/transpiler/backends/cuda/outer_inner/outer_inner_regular_at_same_level_as_attributed_ref.cpp
@@ -1,0 +1,36 @@
+#include <cuda_runtime.h>
+
+extern "C" __global__ __launch_bounds__(10) void _occa_test_kernel_0() {
+  {
+    int i = (0) + blockIdx.y;
+    {
+      int i2 = (0) + blockIdx.x;
+      { int j = (0) + threadIdx.x; }
+      for (int ii = 0; ii < 10; ++ii) {
+        {
+          int j = (0) + threadIdx.x;
+        }
+        for (int j = 0; j < 10; ++j) {
+        }
+      }
+    }
+    for (int ii = 0; ii < 10; ++ii) {
+      {
+        int i = (0) + blockIdx.x;
+        { int j = (0) + threadIdx.x; }
+      }
+    }
+  }
+}
+
+extern "C" __global__ __launch_bounds__(10) void _occa_test_kernel_1() {
+  {
+    int i = (0) + blockIdx.y;
+    for (int i2 = 0; i2 < 10; ++i2) {
+      {
+        int i2 = (0) + blockIdx.x;
+        { int j = (0) + threadIdx.x; }
+      }
+    }
+  }
+}

--- a/tests/functional/data/transpiler/backends/dpcpp/outer_inner/outer_inner_regular_at_same_level_as_attributed.cpp
+++ b/tests/functional/data/transpiler/backends/dpcpp/outer_inner/outer_inner_regular_at_same_level_as_attributed.cpp
@@ -1,0 +1,32 @@
+@kernel void test_kernel() {
+    @outer for (int i = 0; i < 10; ++i) {
+        @outer for (int i2 = 0; i2 < 10; ++i2) {
+            @inner for (int j = 0; j < 10; ++j) {
+            }
+
+            for (int ii = 0; ii < 10; ++ii) {
+                @inner for (int j = 0; j < 10; ++j) {
+                }
+                for (int j = 0; j < 10; ++j) {
+                }
+            }
+        }
+
+        for (int ii = 0; ii < 10; ++ii) {
+            @outer for (int i = 0; i < 10; ++i) {
+                @inner for (int j = 0; j < 10; ++j) {
+                }
+            }
+        }
+    }
+    for (int ii = 0; ii < 10; ++ii) {
+        @outer for (int i = 0; i < 10; ++i) {
+            for (int i2 = 0; i2 < 10; ++i2) {
+                @outer for (int i2 = 0; i2 < 10; ++i2) {
+                    @inner for (int j = 0; j < 10; ++j) {
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/functional/data/transpiler/backends/dpcpp/outer_inner/outer_inner_regular_at_same_level_as_attributed_ref.cpp
+++ b/tests/functional/data/transpiler/backends/dpcpp/outer_inner/outer_inner_regular_at_same_level_as_attributed_ref.cpp
@@ -1,0 +1,47 @@
+#include <CL/sycl.hpp>
+using namespace sycl;
+
+extern "C" [[sycl::reqd_work_group_size(1, 1, 10)]] void
+_occa_test_kernel_0(sycl::queue *queue_, sycl::nd_range<3> *range_) {
+  queue_->submit([&](sycl::handler &handler_) {
+    handler_.parallel_for(*range_, [=](sycl::nd_item<3> item_) {
+      {
+        int i = (0) + item_.get_group(1);
+        {
+          int i2 = (0) + item_.get_group(2);
+          { int j = (0) + item.get_local_id(2); }
+          for (int ii = 0; ii < 10; ++ii) {
+            {
+              int j = (0) + item.get_local_id(2);
+            }
+            for (int j = 0; j < 10; ++j) {
+            }
+          }
+        }
+        for (int ii = 0; ii < 10; ++ii) {
+          {
+            int i = (0) + item_.get_group(2);
+            { int j = (0) + item.get_local_id(2); }
+          }
+        }
+      }
+    });
+  });
+}
+
+extern "C" [[sycl::reqd_work_group_size(1, 1, 10)]] void
+_occa_test_kernel_1(sycl::queue *queue_, sycl::nd_range<3> *range_) {
+  queue_->submit([&](sycl::handler &handler_) {
+    handler_.parallel_for(*range_, [=](sycl::nd_item<3> item_) {
+      {
+        int i = (0) + item_.get_group(1);
+        for (int i2 = 0; i2 < 10; ++i2) {
+          {
+            int i2 = (0) + item_.get_group(2);
+            { int j = (0) + item.get_local_id(2); }
+          }
+        }
+      }
+    });
+  });
+}

--- a/tests/functional/data/transpiler/backends/hip/outer_inner/outer_inner_regular_at_same_level_as_attributed.cpp
+++ b/tests/functional/data/transpiler/backends/hip/outer_inner/outer_inner_regular_at_same_level_as_attributed.cpp
@@ -1,0 +1,32 @@
+@kernel void test_kernel() {
+    @outer for (int i = 0; i < 10; ++i) {
+        @outer for (int i2 = 0; i2 < 10; ++i2) {
+            @inner for (int j = 0; j < 10; ++j) {
+            }
+
+            for (int ii = 0; ii < 10; ++ii) {
+                @inner for (int j = 0; j < 10; ++j) {
+                }
+                for (int j = 0; j < 10; ++j) {
+                }
+            }
+        }
+
+        for (int ii = 0; ii < 10; ++ii) {
+            @outer for (int i = 0; i < 10; ++i) {
+                @inner for (int j = 0; j < 10; ++j) {
+                }
+            }
+        }
+    }
+    for (int ii = 0; ii < 10; ++ii) {
+        @outer for (int i = 0; i < 10; ++i) {
+            for (int i2 = 0; i2 < 10; ++i2) {
+                @outer for (int i2 = 0; i2 < 10; ++i2) {
+                    @inner for (int j = 0; j < 10; ++j) {
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/functional/data/transpiler/backends/hip/outer_inner/outer_inner_regular_at_same_level_as_attributed_ref.cpp
+++ b/tests/functional/data/transpiler/backends/hip/outer_inner/outer_inner_regular_at_same_level_as_attributed_ref.cpp
@@ -1,0 +1,36 @@
+#include <hip/hip_runtime.h>
+
+extern "C" __global__ __launch_bounds__(10) void _occa_test_kernel_0() {
+  {
+    int i = (0) + blockIdx.y;
+    {
+      int i2 = (0) + blockIdx.x;
+      { int j = (0) + threadIdx.x; }
+      for (int ii = 0; ii < 10; ++ii) {
+        {
+          int j = (0) + threadIdx.x;
+        }
+        for (int j = 0; j < 10; ++j) {
+        }
+      }
+    }
+    for (int ii = 0; ii < 10; ++ii) {
+      {
+        int i = (0) + blockIdx.x;
+        { int j = (0) + threadIdx.x; }
+      }
+    }
+  }
+}
+
+extern "C" __global__ __launch_bounds__(10) void _occa_test_kernel_1() {
+  {
+    int i = (0) + blockIdx.y;
+    for (int i2 = 0; i2 < 10; ++i2) {
+      {
+        int i2 = (0) + blockIdx.x;
+        { int j = (0) + threadIdx.x; }
+      }
+    }
+  }
+}

--- a/tests/functional/data/transpiler/backends/launcher/outer_inner/outer_inner_regular_at_same_level_as_attributed.cpp
+++ b/tests/functional/data/transpiler/backends/launcher/outer_inner/outer_inner_regular_at_same_level_as_attributed.cpp
@@ -1,0 +1,32 @@
+@kernel void test_kernel() {
+    @outer for (int i = 0; i < 10; ++i) {
+        @outer for (int i2 = 0; i2 < 10; ++i2) {
+            @inner for (int j = 0; j < 10; ++j) {
+            }
+
+            for (int ii = 0; ii < 10; ++ii) {
+                @inner for (int j = 0; j < 10; ++j) {
+                }
+                for (int j = 0; j < 10; ++j) {
+                }
+            }
+        }
+
+        for (int ii = 0; ii < 10; ++ii) {
+            @outer for (int i = 0; i < 10; ++i) {
+                @inner for (int j = 0; j < 10; ++j) {
+                }
+            }
+        }
+    }
+    for (int ii = 0; ii < 10; ++ii) {
+        @outer for (int i = 0; i < 10; ++i) {
+            for (int i2 = 0; i2 < 10; ++i2) {
+                @outer for (int i2 = 0; i2 < 10; ++i2) {
+                    @inner for (int j = 0; j < 10; ++j) {
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/functional/data/transpiler/backends/launcher/outer_inner/outer_inner_regular_at_same_level_as_attributed_ref.cpp
+++ b/tests/functional/data/transpiler/backends/launcher/outer_inner/outer_inner_regular_at_same_level_as_attributed_ref.cpp
@@ -1,0 +1,34 @@
+#include <occa/core/kernel.hpp>
+
+extern "C" void test_kernel(occa::modeKernel_t **deviceKernels) {
+  {
+    occa::dim outer, inner;
+    outer.dims = 2;
+    inner.dims = 1;
+    int i = 0;
+    outer[1] = (10) - (0);
+    int i2 = 0;
+    outer[0] = (10) - (0);
+    int j = 0;
+    inner[0] = (10) - (0);
+    occa::kernel kernel(deviceKernels[0]);
+    kernel.setRunDims(outer, inner);
+    kernel();
+  };
+  for (int ii = 0; ii < 10; ++ii) {
+    {
+      occa::dim outer, inner;
+      outer.dims = 2;
+      inner.dims = 1;
+      int i = 0;
+      outer[1] = (10) - (0);
+      int i2 = 0;
+      outer[0] = (10) - (0);
+      int j = 0;
+      inner[0] = (10) - (0);
+      occa::kernel kernel(deviceKernels[1]);
+      kernel.setRunDims(outer, inner);
+      kernel();
+    };
+  }
+}

--- a/tests/functional/data/transpiler/backends/openmp/outer_inner/outer_inner_regular_at_same_level_as_attributed.cpp
+++ b/tests/functional/data/transpiler/backends/openmp/outer_inner/outer_inner_regular_at_same_level_as_attributed.cpp
@@ -1,0 +1,32 @@
+@kernel void test_kernel() {
+    @outer for (int i = 0; i < 10; ++i) {
+        @outer for (int i2 = 0; i2 < 10; ++i2) {
+            @inner for (int j = 0; j < 10; ++j) {
+            }
+
+            for (int ii = 0; ii < 10; ++ii) {
+                @inner for (int j = 0; j < 10; ++j) {
+                }
+                for (int j = 0; j < 10; ++j) {
+                }
+            }
+        }
+
+        for (int ii = 0; ii < 10; ++ii) {
+            @outer for (int i = 0; i < 10; ++i) {
+                @inner for (int j = 0; j < 10; ++j) {
+                }
+            }
+        }
+    }
+    for (int ii = 0; ii < 10; ++ii) {
+        @outer for (int i = 0; i < 10; ++i) {
+            for (int i2 = 0; i2 < 10; ++i2) {
+                @outer for (int i2 = 0; i2 < 10; ++i2) {
+                    @inner for (int j = 0; j < 10; ++j) {
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/functional/data/transpiler/backends/openmp/outer_inner/outer_inner_regular_at_same_level_as_attributed_ref.cpp
+++ b/tests/functional/data/transpiler/backends/openmp/outer_inner/outer_inner_regular_at_same_level_as_attributed_ref.cpp
@@ -1,0 +1,32 @@
+extern "C" void test_kernel() {
+#pragma omp parallel for
+  for (int i = 0; i < 10; ++i) {
+    for (int i2 = 0; i2 < 10; ++i2) {
+      for (int j = 0; j < 10; ++j) {
+      }
+      for (int ii = 0; ii < 10; ++ii) {
+        for (int j = 0; j < 10; ++j) {
+        }
+        for (int j = 0; j < 10; ++j) {
+        }
+      }
+    }
+    for (int ii = 0; ii < 10; ++ii) {
+      for (int i = 0; i < 10; ++i) {
+        for (int j = 0; j < 10; ++j) {
+        }
+      }
+    }
+  }
+  for (int ii = 0; ii < 10; ++ii) {
+#pragma omp parallel for
+    for (int i = 0; i < 10; ++i) {
+      for (int i2 = 0; i2 < 10; ++i2) {
+        for (int i2 = 0; i2 < 10; ++i2) {
+          for (int j = 0; j < 10; ++j) {
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/functional/data/transpiler/backends/serial/outer_inner/outer_inner_regular_at_same_level_as_attributed.cpp
+++ b/tests/functional/data/transpiler/backends/serial/outer_inner/outer_inner_regular_at_same_level_as_attributed.cpp
@@ -1,0 +1,32 @@
+@kernel void test_kernel() {
+    @outer for (int i = 0; i < 10; ++i) {
+        @outer for (int i2 = 0; i2 < 10; ++i2) {
+            @inner for (int j = 0; j < 10; ++j) {
+            }
+
+            for (int ii = 0; ii < 10; ++ii) {
+                @inner for (int j = 0; j < 10; ++j) {
+                }
+                for (int j = 0; j < 10; ++j) {
+                }
+            }
+        }
+
+        for (int ii = 0; ii < 10; ++ii) {
+            @outer for (int i = 0; i < 10; ++i) {
+                @inner for (int j = 0; j < 10; ++j) {
+                }
+            }
+        }
+    }
+    for (int ii = 0; ii < 10; ++ii) {
+        @outer for (int i = 0; i < 10; ++i) {
+            for (int i2 = 0; i2 < 10; ++i2) {
+                @outer for (int i2 = 0; i2 < 10; ++i2) {
+                    @inner for (int j = 0; j < 10; ++j) {
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/functional/data/transpiler/backends/serial/outer_inner/outer_inner_regular_at_same_level_as_attributed_ref.cpp
+++ b/tests/functional/data/transpiler/backends/serial/outer_inner/outer_inner_regular_at_same_level_as_attributed_ref.cpp
@@ -1,0 +1,30 @@
+extern "C" void test_kernel() {
+  for (int i = 0; i < 10; ++i) {
+    for (int i2 = 0; i2 < 10; ++i2) {
+      for (int j = 0; j < 10; ++j) {
+      }
+      for (int ii = 0; ii < 10; ++ii) {
+        for (int j = 0; j < 10; ++j) {
+        }
+        for (int j = 0; j < 10; ++j) {
+        }
+      }
+    }
+    for (int ii = 0; ii < 10; ++ii) {
+      for (int i = 0; i < 10; ++i) {
+        for (int j = 0; j < 10; ++j) {
+        }
+      }
+    }
+  }
+  for (int ii = 0; ii < 10; ++ii) {
+    for (int i = 0; i < 10; ++i) {
+      for (int i2 = 0; i2 < 10; ++i2) {
+        for (int i2 = 0; i2 < 10; ++i2) {
+          for (int j = 0; j < 10; ++j) {
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fix adding loop children to the tree in structure check for case when attributed loops is followed by regular. Add test case for this.
Should fix https://github.com/libocca/occa-transpiler/issues/208 
