### PR TITLE
Add compound statement support to @atomic dpcpp

### DIFF
--- a/lib/attributes/backend/dpcpp/atomic.cpp
+++ b/lib/attributes/backend/dpcpp/atomic.cpp
@@ -78,6 +78,8 @@ tl::expected<std::string, Error> buildNewExpression(SessionStage& stage,
                                                     const Attr& attr,
                                                     const clang::Stmt& stmt);
 
+// TODO: Replicates legacy occa transpiler behavior. Seems to be incorrect that each statement is
+// made atomic, and not the whole block.
 tl::expected<std::string, Error> buildCompoundStmt(SessionStage& stage,
                                                    const Attr& attr,
                                                    const CompoundStmt& op) {

--- a/lib/attributes/backend/dpcpp/atomic.cpp
+++ b/lib/attributes/backend/dpcpp/atomic.cpp
@@ -74,26 +74,52 @@ tl::expected<std::string, Error> buildCXXCopyOp(SessionStage& stage,
         rigthStr);
 }
 
+tl::expected<std::string, Error> buildNewExpression(SessionStage& stage,
+                                                    const Attr& attr,
+                                                    const clang::Stmt& stmt);
+
+tl::expected<std::string, Error> buildCompoundStmt(SessionStage& stage,
+                                                   const Attr& attr,
+                                                   const CompoundStmt& op) {
+    std::string res = "{";
+    for (auto& stmt : op.body()) {
+        auto newExpr = buildNewExpression(stage, attr, *stmt);
+        if (!newExpr) {
+            return tl::make_unexpected(newExpr.error());
+        }
+        res += newExpr.value() + ";\n";
+    }
+    res += "}";
+    return res;
+}
+
+tl::expected<std::string, Error> buildNewExpression(SessionStage& stage,
+                                                    const Attr& attr,
+                                                    const clang::Stmt& stmt) {
+    if (isa<BinaryOperator>(stmt)) {
+        const BinaryOperator* binOp = cast<BinaryOperator>(&stmt);
+        return buildBinOp(stage, attr, *binOp);
+    }
+    if (isa<UnaryOperator>(stmt)) {
+        const UnaryOperator* unOp = cast<UnaryOperator>(&stmt);
+        return buildUnOp(stage, attr, *unOp);
+    }
+    if (isa<CXXOperatorCallExpr>(stmt)) {
+        const CXXOperatorCallExpr* op = cast<CXXOperatorCallExpr>(&stmt);
+        return buildCXXCopyOp(stage, attr, *op);
+    }
+    if (isa<CompoundStmt>(stmt)) {
+        const CompoundStmt* compoundStmt = cast<CompoundStmt>(&stmt);
+        return buildCompoundStmt(stage, attr, *compoundStmt);
+    }
+    return tl::make_unexpected(Error{{}, "Error: Unable to transform general @atomic code"});
+}
+
 HandleResult handleAtomicAttribute(SessionStage& stage,
                                    const clang::Stmt& stmt,
                                    const clang::Attr& attr) {
     auto& ctx = stage.getCompiler().getASTContext();
-    auto newExpression = [&]() -> tl::expected<std::string, Error> {
-        if (isa<BinaryOperator>(stmt)) {
-            const BinaryOperator* binOp = cast<BinaryOperator>(&stmt);
-            return buildBinOp(stage, attr, *binOp);
-        }
-        if (isa<UnaryOperator>(stmt)) {
-            const UnaryOperator* unOp = cast<UnaryOperator>(&stmt);
-            return buildUnOp(stage, attr, *unOp);
-        }
-        if (isa<CXXOperatorCallExpr>(stmt)) {
-            const CXXOperatorCallExpr* op = cast<CXXOperatorCallExpr>(&stmt);
-            return buildCXXCopyOp(stage, attr, *op);
-        }
-
-        return getSourceText(*dyn_cast<Expr>(&stmt), ctx);
-    }();
+    auto newExpression = buildNewExpression(stage, attr, stmt);
     if (!newExpression) {
         return tl::make_unexpected(newExpression.error());
     }

--- a/tests/functional/configs/test_suite_transpiler/backends/dpcpp/atomic.json
+++ b/tests/functional/configs/test_suite_transpiler/backends/dpcpp/atomic.json
@@ -86,5 +86,16 @@
             "launcher": ""
         },
         "reference": "transpiler/backends/dpcpp/atomic/atomic_dec_ref.cpp"
-     }
+     },
+     {
+        "action": "normalize_and_transpile",
+        "action_config": {
+            "backend": "dpcpp",
+            "source": "transpiler/backends/dpcpp/atomic/atomic_compound_statement.cpp",
+            "includes": [],
+            "defs": [],
+            "launcher": ""
+        },
+        "reference": "transpiler/backends/dpcpp/atomic/atomic_compound_statement_ref.cpp"
+    }
 ]

--- a/tests/functional/data/transpiler/backends/dpcpp/atomic/atomic_compound_statement.cpp
+++ b/tests/functional/data/transpiler/backends/dpcpp/atomic/atomic_compound_statement.cpp
@@ -1,0 +1,11 @@
+@kernel void test_kernel() {
+    @outer for (int i = 0; i < 32; ++i) {
+        @shared float shm[32];
+        @inner for (int j = 0; j < 32; ++j) {
+            @atomic {
+                shm[i*j]++;
+                j += 32;
+            }
+        }
+    }
+}

--- a/tests/functional/data/transpiler/backends/dpcpp/atomic/atomic_compound_statement_ref.cpp
+++ b/tests/functional/data/transpiler/backends/dpcpp/atomic/atomic_compound_statement_ref.cpp
@@ -1,0 +1,29 @@
+#include <CL/sycl.hpp>
+using namespace sycl;
+
+extern "C" [[sycl::reqd_work_group_size(1, 1, 32)]] void
+_occa_test_kernel_0(sycl::queue *queue_, sycl::nd_range<3> *range_) {
+  queue_->submit([&](sycl::handler &handler_) {
+    handler_.parallel_for(*range_, [=](sycl::nd_item<3> item_) {
+      {
+        int i = (0) + item_.get_group(2);
+        auto &shm =
+            *(sycl::ext::oneapi::group_local_memory_for_overwrite<float[32]>(
+                item_.get_group()));
+        {
+          int j = (0) + item.get_local_id(2);
+          {
+            sycl::atomic_ref<float, sycl::memory_order::relaxed,
+                             sycl::memory_scope::device,
+                             sycl::access::address_space::global_space>(
+                shm[i * j])++;
+            sycl::atomic_ref<int, sycl::memory_order::relaxed,
+                             sycl::memory_scope::device,
+                             sycl::access::address_space::global_space>(j) +=
+                32;
+          }
+        }
+      }
+    });
+  });
+}


### PR DESCRIPTION
NOTE: branched from unmerged (yet) enhancement/attributes_specification

Add support for compound statement for @atomic handler for dpcpp backend. Should fix https://github.com/libocca/occa-transpiler/issues/215 