### PR TITLE
Fix hip and cuda intrisics

### DIFF
--- a/lib/resources/okl_intrinsic_cuda.h
+++ b/lib/resources/okl_intrinsic_cuda.h
@@ -30,7 +30,7 @@ template<class T>
 inline __device__
 T okl_shfl_xor_sync(unsigned mask, T var, int laneMask, int width=warpSize)
 {
-    return __shfl_xor_sync(mask, laneMask, width);
+    return __shfl_xor_sync(mask, var, laneMask, width);
 }
 
 // Pipeline Primitives Interface

--- a/lib/resources/okl_intrinsic_hip.h
+++ b/lib/resources/okl_intrinsic_hip.h
@@ -29,7 +29,7 @@ template<class T>
 inline __device__
     T okl_shfl_xor_sync(unsigned mask, T var, int laneMask, int width=warpSize)
 {
-    return __shfl_xor_sync(mask, laneMask, width);
+    return __shfl_xor_sync(mask, var, laneMask, width);
 }
 
 
@@ -55,6 +55,6 @@ inline __device__ void okl_pipeline_commit() {
 }
 
 [[maybe_unused]]
-inline __device__ void __pipeline_wait_prior(size_t N) {
+inline __device__ void okl_pipeline_wait_prior(size_t N) {
 }
 }


### PR DESCRIPTION
__shfl_xor_sync was used wrongly on both cuda and hip
rename __pipeline_wait_prior -> okl_pipeline_wait_prior